### PR TITLE
fix(user): 회원가입 이메일 인증 흐름 재설계 및 버그 수정

### DIFF
--- a/src/main/java/com/sollite/user/controller/AuthController.java
+++ b/src/main/java/com/sollite/user/controller/AuthController.java
@@ -9,10 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 /**
  * 사용자 인증 관련 API 컨트롤러.
@@ -78,6 +76,18 @@ public class AuthController {
     public ResponseEntity<MessageResponse> confirmEmailVerification(@Valid @RequestBody EmailVerifyConfirmRequest request) {
         userService.confirmEmailVerification(request);
         return ResponseEntity.ok(new MessageResponse("이메일 인증이 완료되었습니다."));
+    }
+
+    /**
+     * 이메일 인증 완료 여부를 조회합니다. 회원가입 페이지에서 폴링용으로 사용합니다.
+     *
+     * @param email 이메일 주소
+     * @return 200 OK - 인증 완료 여부
+     */
+    @GetMapping("/email/verify/status")
+    public ResponseEntity<EmailVerifyStatusResponse> checkEmailVerifyStatus(@RequestParam String email) {
+        boolean verified = userService.checkEmailVerified(email);
+        return ResponseEntity.ok(new EmailVerifyStatusResponse(verified));
     }
 
     /**

--- a/src/main/java/com/sollite/user/domain/entity/User.java
+++ b/src/main/java/com/sollite/user/domain/entity/User.java
@@ -50,26 +50,11 @@ public class User {
     @Column(name = "withdrawn_at")
     private LocalDateTime withdrawnAt;
 
-    @Column(name = "service_terms_agreed_yn", nullable = false, columnDefinition = "CHAR(1)")
-    private String serviceTermsAgreedYn = "N";
-
-    @Column(name = "privacy_terms_agreed_yn", nullable = false, columnDefinition = "CHAR(1)")
-    private String privacyTermsAgreedYn = "N";
-
-    @Column(name = "marketing_agreed_yn", nullable = false, columnDefinition = "CHAR(1)")
-    private String marketingAgreedYn = "N";
-
-    @Column(name = "terms_agreed_at")
-    private LocalDateTime termsAgreedAt;
-
     @Column(name = "default_market", length = 10)
     private String defaultMarket = "DOMESTIC";
 
     @Column(length = 20)
     private String theme = "LIGHT";
-
-    @Column(length = 10)
-    private String language = "KO";
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -80,16 +65,11 @@ public class User {
     private LocalDateTime updatedAt;
 
     @Builder
-    public User(String email, String passwordHash, String name, String phone,
-                boolean serviceTermsAgreed, boolean privacyTermsAgreed, boolean marketingAgreed) {
+    public User(String email, String passwordHash, String name, String phone) {
         this.email = email;
         this.passwordHash = passwordHash;
         this.name = name;
         this.phone = phone;
-        this.serviceTermsAgreedYn = serviceTermsAgreed ? "Y" : "N";
-        this.privacyTermsAgreedYn = privacyTermsAgreed ? "Y" : "N";
-        this.marketingAgreedYn = marketingAgreed ? "Y" : "N";
-        this.termsAgreedAt = LocalDateTime.now();
     }
 
     public void verifyEmail() {

--- a/src/main/java/com/sollite/user/domain/entity/UserConsent.java
+++ b/src/main/java/com/sollite/user/domain/entity/UserConsent.java
@@ -2,12 +2,14 @@ package com.sollite.user.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_consents")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserConsent {
 

--- a/src/main/java/com/sollite/user/domain/entity/UserConsent.java
+++ b/src/main/java/com/sollite/user/domain/entity/UserConsent.java
@@ -1,0 +1,39 @@
+package com.sollite.user.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_consents")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserConsent {
+
+    @Id
+    private Long userId;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "service_terms_agreed_yn", nullable = false, columnDefinition = "CHAR(1)")
+    private String serviceTermsAgreedYn;
+
+    @Column(name = "privacy_terms_agreed_yn", nullable = false, columnDefinition = "CHAR(1)")
+    private String privacyTermsAgreedYn;
+
+    @Column(name = "terms_agreed_at", nullable = false)
+    private LocalDateTime termsAgreedAt;
+
+    public static UserConsent of(User user, boolean serviceTermsAgreed, boolean privacyTermsAgreed) {
+        UserConsent consent = new UserConsent();
+        consent.user = user;
+        consent.serviceTermsAgreedYn = serviceTermsAgreed ? "Y" : "N";
+        consent.privacyTermsAgreedYn = privacyTermsAgreed ? "Y" : "N";
+        consent.termsAgreedAt = LocalDateTime.now();
+        return consent;
+    }
+}

--- a/src/main/java/com/sollite/user/domain/repository/UserConsentRepository.java
+++ b/src/main/java/com/sollite/user/domain/repository/UserConsentRepository.java
@@ -1,0 +1,7 @@
+package com.sollite.user.domain.repository;
+
+import com.sollite.user.domain.entity.UserConsent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserConsentRepository extends JpaRepository<UserConsent, Long> {
+}

--- a/src/main/java/com/sollite/user/dto/EmailVerifyStatusResponse.java
+++ b/src/main/java/com/sollite/user/dto/EmailVerifyStatusResponse.java
@@ -1,0 +1,4 @@
+package com.sollite.user.dto;
+
+public record EmailVerifyStatusResponse(boolean verified) {
+}

--- a/src/main/java/com/sollite/user/dto/SignupRequest.java
+++ b/src/main/java/com/sollite/user/dto/SignupRequest.java
@@ -20,6 +20,7 @@ public record SignupRequest(
         @NotBlank(message = "이름은 필수입니다")
         String name,
 
+        @NotBlank(message = "전화번호는 필수입니다")
         @Pattern(
                 regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
                 message = "전화번호는 010-1234-5678 형식으로 입력하세요"

--- a/src/main/java/com/sollite/user/dto/SignupRequest.java
+++ b/src/main/java/com/sollite/user/dto/SignupRequest.java
@@ -20,17 +20,16 @@ public record SignupRequest(
         @NotBlank(message = "이름은 필수입니다")
         String name,
 
+        @Pattern(
+                regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
+                message = "전화번호는 010-1234-5678 형식으로 입력하세요"
+        )
         String phone,
 
         @AssertTrue(message = "서비스 이용약관에 동의해야 합니다")
         Boolean serviceTermsAgreed,
 
         @AssertTrue(message = "개인정보처리방침에 동의해야 합니다")
-        Boolean privacyTermsAgreed,
-
-        Boolean marketingAgreed
+        Boolean privacyTermsAgreed
 ) {
-    public SignupRequest {
-        if (marketingAgreed == null) marketingAgreed = false;
-    }
 }

--- a/src/main/java/com/sollite/user/service/EmailService.java
+++ b/src/main/java/com/sollite/user/service/EmailService.java
@@ -30,8 +30,8 @@ public class EmailService {
     private final StringRedisTemplate redisTemplate;
     private final TemplateEngine templateEngine;
 
-    @Value("${app.base-url}")
-    private String baseUrl;
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
 
     @Value("${app.mail.from}")
     private String mailFrom;
@@ -43,21 +43,19 @@ public class EmailService {
     private static final String PW_RESET_LIMIT     = "pw_reset_limit:";
 
     /**
-     * 이메일 인증 메일을 발송합니다.
+     * 이메일 인증 메일을 발송합니다. 회원가입 전에도 호출 가능합니다.
      *
      * @param email 발송할 이메일 주소
-     * @param userId 사용자 ID
      * @throws BusinessException 재발송 제한 초과 시
      * @throws BusinessException 이메일 발송 실패 시
      */
-    public void sendVerificationEmail(String email, Long userId) {
+    public void sendVerificationEmail(String email) {
         String rateLimitKey = EMAIL_VERIFY_LIMIT + email;
         checkRateLimit(rateLimitKey);
 
         String token = UUID.randomUUID().toString();
 
         redisTemplate.opsForHash().putAll("email_verify:" + token, Map.of(
-                "user_id", String.valueOf(userId),
                 "email", email,
                 "created_at", java.time.LocalDateTime.now().toString()
         ));
@@ -68,13 +66,13 @@ public class EmailService {
     }
 
     /**
-     * 이메일 인증 토큰을 검증하고 사용자 정보를 반환합니다. 토큰은 1회용이므로 사용 후 삭제됩니다.
+     * 이메일 인증 토큰을 검증하고 인증 완료 상태를 Redis에 저장합니다. 토큰은 1회용이므로 사용 후 삭제됩니다.
      *
      * @param token 이메일 인증 토큰
-     * @return 사용자 ID와 이메일 주소
+     * @return 인증된 이메일 주소
      * @throws BusinessException 토큰 만료 또는 유효하지 않은 토큰 시
      */
-    public Map<String, String> verifyToken(String token) {
+    public String verifyToken(String token) {
         String key = "email_verify:" + token;
         Map<Object, Object> data = redisTemplate.opsForHash().entries(key);
 
@@ -85,10 +83,12 @@ public class EmailService {
         // 토큰 사용 후 삭제 (1회용)
         redisTemplate.delete(key);
 
-        return Map.of(
-                "user_id", (String) data.get("user_id"),
-                "email", (String) data.get("email")
-        );
+        String email = (String) data.get("email");
+
+        // 인증 완료 표시 저장 (회원가입 시 검증용, 30분 유효)
+        redisTemplate.opsForValue().set("email_verified:" + email, "true", VERIFY_TOKEN_TTL, TimeUnit.MINUTES);
+
+        return email;
     }
 
     /**
@@ -168,7 +168,7 @@ public class EmailService {
             helper.setSubject("[SOL-Lite] 비밀번호 재설정");
             helper.setFrom(mailFrom);
 
-            String resetUrl = baseUrl + "/api/auth/password/reset/confirm?token=" + token;
+            String resetUrl = frontendUrl + "/password/reset?token=" + token;
 
             Context context = new Context();
             context.setVariable("resetUrl", resetUrl);
@@ -191,7 +191,7 @@ public class EmailService {
             helper.setSubject("[SOL-Lite] 이메일 인증");
             helper.setFrom(mailFrom);
 
-            String verifyUrl = baseUrl + "/api/auth/email/verify/confirm?token=" + token;
+            String verifyUrl = frontendUrl + "/email/verify?token=" + token;
 
             Context context = new Context();
             context.setVariable("verifyUrl", verifyUrl);

--- a/src/main/java/com/sollite/user/service/UserService.java
+++ b/src/main/java/com/sollite/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.sollite.user.service;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.global.security.JwtTokenProvider;
 import com.sollite.user.domain.entity.User;
+import com.sollite.user.domain.entity.UserConsent;
+import com.sollite.user.domain.repository.UserConsentRepository;
 import com.sollite.user.domain.repository.UserRepository;
 import com.sollite.user.dto.*;
 import com.sollite.user.exception.UserErrorCode;
@@ -23,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserConsentRepository userConsentRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final StringRedisTemplate redisTemplate;
@@ -55,14 +58,13 @@ public class UserService {
                 .email(request.email())
                 .passwordHash(passwordEncoder.encode(request.password()))
                 .name(request.name())
-                .phone(request.phone())
-                .serviceTermsAgreed(request.serviceTermsAgreed())
-                .privacyTermsAgreed(request.privacyTermsAgreed())
-                .marketingAgreed(request.marketingAgreed())
+                .phone(request.phone() != null ? request.phone().replaceAll("-", "") : null)
                 .build();
 
         user.verifyEmail();
         userRepository.save(user);
+
+        userConsentRepository.save(UserConsent.of(user, request.serviceTermsAgreed(), request.privacyTermsAgreed()));
 
         // 사용한 인증 키 삭제
         redisTemplate.delete("email_verified:" + request.email());
@@ -186,11 +188,15 @@ public class UserService {
     }
 
     /**
-     * 이메일 인증 메일을 발송합니다. 회원가입 전에도 호출 가능합니다.
+     * 이메일 인증 메일을 발송합니다. 이미 가입된 이메일이면 즉시 오류를 반환합니다.
      *
      * @param request 이메일 주소
+     * @throws BusinessException 이미 가입된 이메일인 경우
      */
     public void sendVerificationEmail(EmailVerifyRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
+        }
         emailService.sendVerificationEmail(request.email());
     }
 
@@ -296,7 +302,8 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        user.updateProfile(request.name(), request.phone());
+        String phone = request.phone() != null ? request.phone().replaceAll("-", "") : null;
+        user.updateProfile(request.name(), phone);
 
         return new UserProfileResponse(
                 user.getUserId(),

--- a/src/main/java/com/sollite/user/service/UserService.java
+++ b/src/main/java/com/sollite/user/service/UserService.java
@@ -43,6 +43,10 @@ public class UserService {
             throw new BusinessException(UserErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
 
+        if (!checkEmailVerified(request.email())) {
+            throw new BusinessException(UserErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
         if (userRepository.existsByEmail(request.email())) {
             throw new BusinessException(UserErrorCode.DUPLICATE_EMAIL);
         }
@@ -57,13 +61,17 @@ public class UserService {
                 .marketingAgreed(request.marketingAgreed())
                 .build();
 
+        user.verifyEmail();
         userRepository.save(user);
+
+        // 사용한 인증 키 삭제
+        redisTemplate.delete("email_verified:" + request.email());
 
         return new SignupResponse(
                 user.getUserId(),
                 user.getEmail(),
                 user.getName(),
-                "회원가입이 완료되었습니다. 이메일 인증을 진행해주세요."
+                "회원가입이 완료되었습니다."
         );
     }
 
@@ -178,13 +186,22 @@ public class UserService {
     }
 
     /**
-     * 이메일 인증 메일을 발송합니다. 사용자 존재 여부와 무관하게 항상 성공 응답을 반환합니다 (User Enumeration 방지).
+     * 이메일 인증 메일을 발송합니다. 회원가입 전에도 호출 가능합니다.
      *
      * @param request 이메일 주소
      */
     public void sendVerificationEmail(EmailVerifyRequest request) {
-        userRepository.findByEmail(request.email())
-                .ifPresent(user -> emailService.sendVerificationEmail(user.getEmail(), user.getUserId()));
+        emailService.sendVerificationEmail(request.email());
+    }
+
+    /**
+     * 이메일 인증 완료 여부를 확인합니다. 프론트에서 폴링용으로 사용합니다.
+     *
+     * @param email 이메일 주소
+     * @return 인증 완료 여부
+     */
+    public boolean checkEmailVerified(String email) {
+        return "true".equals(redisTemplate.opsForValue().get("email_verified:" + email));
     }
 
     /**
@@ -292,19 +309,12 @@ public class UserService {
     }
 
     /**
-     * 이메일 인증 토큰을 검증하고 사용자의 이메일을 인증 처리합니다.
+     * 이메일 인증 토큰을 검증합니다. 인증 완료 상태는 Redis에 저장되며 회원가입 시 검증됩니다.
      *
      * @param request 이메일 인증 토큰
-     * @throws BusinessException 토큰 만료, 사용자 미등록 시
+     * @throws BusinessException 토큰 만료 시
      */
-    @Transactional
     public void confirmEmailVerification(EmailVerifyConfirmRequest request) {
-        java.util.Map<String, String> tokenData = emailService.verifyToken(request.token());
-
-        Long userId = Long.parseLong(tokenData.get("user_id"));
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        user.verifyEmail();
+        emailService.verifyToken(request.token());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,7 @@ jwt:
 # ── Application URLs ──
 app:
   base-url: ${APP_BASE_URL:http://localhost:8080}
+  frontend-url: ${APP_FRONTEND_URL:http://localhost:5173}
   mail:
     from: ${MAIL_FROM}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,11 +15,9 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.OracleDialect
-        format_sql: true
+      ddl-auto: update
+      dialect: org.hibernate.dialect.OracleDialect
+      format_sql: true
     show-sql: true
 
   # ── Flyway ──
@@ -88,3 +86,4 @@ logging:
   level:
     com.sollite: DEBUG
     org.hibernate.SQL: DEBUG
+

--- a/src/main/resources/db/migration/V2__drop_marketing_agreed.sql
+++ b/src/main/resources/db/migration/V2__drop_marketing_agreed.sql
@@ -1,0 +1,15 @@
+-- users 테이블 정리
+ALTER TABLE users DROP COLUMN marketing_agreed_yn;
+ALTER TABLE users DROP COLUMN service_terms_agreed_yn;
+ALTER TABLE users DROP COLUMN privacy_terms_agreed_yn;
+ALTER TABLE users DROP COLUMN terms_agreed_at;
+ALTER TABLE users DROP COLUMN language;
+
+-- 동의 이력 테이블 분리
+CREATE TABLE user_consents (
+    user_id                  NUMBER(19,0)  PRIMARY KEY,
+    service_terms_agreed_yn  CHAR(1)       DEFAULT 'N' NOT NULL,
+    privacy_terms_agreed_yn  CHAR(1)       DEFAULT 'N' NOT NULL,
+    terms_agreed_at          TIMESTAMP     NOT NULL,
+    CONSTRAINT fk_uconsents_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+);


### PR DESCRIPTION
## Summary

- 이메일 인증 흐름을 회원가입 전에도 동작하도록 재설계 (closes #6)
- 이메일 링크를 백엔드 직접 호출 → 프론트엔드 URL로 변경 (closes #1)
- `app.frontend-url` 환경변수 추가 (`APP_FRONTEND_URL`, 기본값: `http://localhost:5173`)

## 변경 내용

### 이메일 인증 흐름 재설계 (#6)

**기존 문제**
- `sendVerificationEmail`이 이미 가입된 유저에게만 발송 가능 → 회원가입 전 인증 불가
- 인증 완료 여부 확인 API 없음 → 프론트에서 다음 단계 활성화 불가

**변경 후 흐름**
```
이메일 입력 → POST /api/auth/email/verify/send (가입 전 호출 가능)
                      ↓
           이메일 링크 클릭 → POST /api/auth/email/verify/confirm
           → Redis에 email_verified:{email} 저장 (30분)
                      ↓
           GET /api/auth/email/verify/status?email=xxx 폴링
           → verified: true 되면 다음 단계 활성화
                      ↓
           POST /api/auth/signup → Redis 인증 여부 검증 후 가입
```

### 이메일 링크 URL 수정 (#1)

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 인증 링크 | `{backendUrl}/api/auth/email/verify/confirm?token=` | `{frontendUrl}/email/verify?token=` |
| 비밀번호 재설정 링크 | `{backendUrl}/api/auth/password/reset/confirm?token=` | `{frontendUrl}/password/reset?token=` |

## 프론트팀 연동 필요 사항

1. `/email/verify?token=xxx` 페이지 → `POST /api/auth/email/verify/confirm` 호출
2. `/password/reset?token=xxx` 페이지 → 새 비밀번호 폼 + `POST /api/auth/password/reset/confirm` 호출
3. 회원가입 페이지에서 `GET /api/auth/email/verify/status?email=xxx` 폴링 (2~3초 간격)

## Test plan

- [ ] 회원가입 전(미가입 이메일) 인증 발송 → 이메일 수신 확인
- [ ] 이메일 링크 클릭 → 프론트 `/email/verify` 페이지로 이동 확인
- [ ] `GET /api/auth/email/verify/status` 폴링 → 인증 전 `false`, 인증 후 `true` 확인
- [ ] 인증 완료 후 `POST /api/auth/signup` → 정상 가입 확인
- [ ] 인증 없이 `POST /api/auth/signup` → `EMAIL_NOT_VERIFIED` 에러 확인
- [ ] 비밀번호 재설정 링크 → 프론트 `/password/reset` 페이지로 이동 확인