### PR TITLE
chore(user): Flyway V3 마이그레이션 파일 정리 및 ddl-auto 복구

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
       dialect: org.hibernate.dialect.OracleDialect
       format_sql: true
     show-sql: true

--- a/src/main/resources/db/migration/V2__alter_instruments_add_ls_columns.sql
+++ b/src/main/resources/db/migration/V2__alter_instruments_add_ls_columns.sql
@@ -1,0 +1,12 @@
+-- LS증권 API 기준 instruments 테이블 컬럼 추가
+--
+-- t9945 (주식마스터조회) 응답 필드 매핑:
+--   expcode  → standard_code : 확장코드(표준코드). 국내 예) KR7000020008 / 해외 예) NASAAPL
+--   etfchk   → etf_yn        : ETF 구분. 1=ETF(Y), 0=일반(N)
+--   nxt_chk  → nxt_yn        : NXT 거래소 제공 여부. 1=제공(Y), 0=미제공(N)
+
+ALTER TABLE instruments ADD standard_code VARCHAR2(20);
+ALTER TABLE instruments ADD etf_yn        CHAR(1) DEFAULT 'N' NOT NULL;
+ALTER TABLE instruments ADD nxt_yn        CHAR(1) DEFAULT 'N' NOT NULL;
+
+CREATE UNIQUE INDEX uq_instruments_standard_code ON instruments (standard_code);

--- a/src/main/resources/db/migration/V3__drop_marketing_agreed.sql
+++ b/src/main/resources/db/migration/V3__drop_marketing_agreed.sql
@@ -1,5 +1,12 @@
 -- users 테이블에서 불필요한 컬럼 제거
 -- 동의 이력을 별도 테이블로 관리
+-- users 테이블에서 불필요한 컬럼 제거
+ALTER TABLE users DROP COLUMN marketing_agreed_yn;
+ALTER TABLE users DROP COLUMN service_terms_agreed_yn;
+ALTER TABLE users DROP COLUMN privacy_terms_agreed_yn;
+ALTER TABLE users DROP COLUMN terms_agreed_at;
+ALTER TABLE users DROP COLUMN language;
+
 
 CREATE TABLE user_consents (
     user_id                  NUMBER(19,0)  PRIMARY KEY,

--- a/src/main/resources/db/migration/V3__drop_marketing_agreed.sql
+++ b/src/main/resources/db/migration/V3__drop_marketing_agreed.sql
@@ -1,11 +1,6 @@
--- users 테이블 정리
-ALTER TABLE users DROP COLUMN marketing_agreed_yn;
-ALTER TABLE users DROP COLUMN service_terms_agreed_yn;
-ALTER TABLE users DROP COLUMN privacy_terms_agreed_yn;
-ALTER TABLE users DROP COLUMN terms_agreed_at;
-ALTER TABLE users DROP COLUMN language;
+-- users 테이블에서 불필요한 컬럼 제거
+-- 동의 이력을 별도 테이블로 관리
 
--- 동의 이력 테이블 분리
 CREATE TABLE user_consents (
     user_id                  NUMBER(19,0)  PRIMARY KEY,
     service_terms_agreed_yn  CHAR(1)       DEFAULT 'N' NOT NULL,


### PR DESCRIPTION
## Summary
- `V2__drop_marketing_agreed.sql` → `V3__drop_marketing_agreed.sql` 파일명 변경 (V1과 충돌 방지)
- `application.yml` `ddl-auto: update` → `validate` 복구

## 관련 이슈
- Flyway 마이그레이션 순서 정합성 유지