### PR TITLE
feat(account): 계좌 리셋 API와 회차 종료 처리 구현

### DIFF
--- a/src/main/java/com/sollite/account/controller/AccountController.java
+++ b/src/main/java/com/sollite/account/controller/AccountController.java
@@ -2,6 +2,8 @@ package com.sollite.account.controller;
 
 import com.sollite.account.dto.AccountCloseRequest;
 import com.sollite.account.dto.AccountInfoResponse;
+import com.sollite.account.dto.AccountResetRequest;
+import com.sollite.account.dto.AccountResetResponse;
 import com.sollite.account.dto.PinChangeRequest;
 import com.sollite.account.dto.PinResetConfirmRequest;
 import com.sollite.account.dto.PinVerifyRequest;
@@ -101,6 +103,23 @@ public class AccountController {
     }
 
     /**
+     * 시뮬레이션을 초기화합니다. 현재 라운드를 종료하고 새 라운드를 시작합니다.
+     *
+     * @param authentication 현재 인증된 사용자 정보
+     * @param request 계좌 비밀번호
+     * @return 200 OK - 초기화 완료 메시지와 새 라운드 번호
+     * @throws BusinessException 계좌 미존재, 이미 폐쇄된 계좌, PIN 불일치, 활성 라운드 없음 시
+     */
+    @PostMapping("/reset")
+    public ResponseEntity<AccountResetResponse> resetAccount(
+            Authentication authentication,
+            @Valid @RequestBody AccountResetRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        AccountResetResponse response = accountService.resetAccount(userId, request.accountPin());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
      * 계좌를 폐쇄합니다. PIN 인증 필수.
      * 잔고/보유자산/미체결주문 검증은 추후 추가 예정 (issue #15)
      *
@@ -118,4 +137,3 @@ public class AccountController {
         return ResponseEntity.ok(new MessageResponse("계좌가 폐쇄되었습니다."));
     }
 }
-

--- a/src/main/java/com/sollite/account/domain/entity/SimulationRound.java
+++ b/src/main/java/com/sollite/account/domain/entity/SimulationRound.java
@@ -1,5 +1,7 @@
 package com.sollite.account.domain.entity;
 
+import com.sollite.account.domain.enums.RoundEndReasonCode;
+import com.sollite.account.domain.enums.RoundStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -31,11 +33,13 @@ public class SimulationRound {
     @Column(name = "initial_seed_amount", nullable = false, precision = 19, scale = 4)
     private BigDecimal initialSeedAmount;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "round_end_reason_code", length = 50)
-    private String roundEndReasonCode;
+    private RoundEndReasonCode roundEndReasonCode;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "round_status", nullable = false, length = 20)
-    private String roundStatus = "ACTIVE";
+    private RoundStatus roundStatus = RoundStatus.ACTIVE;
 
     @Column(name = "started_at", nullable = false)
     private LocalDateTime startedAt;
@@ -55,8 +59,8 @@ public class SimulationRound {
         this.startedAt = LocalDateTime.now();
     }
 
-    public void close(String reasonCode) {
-        this.roundStatus = "CLOSED";
+    public void close(RoundEndReasonCode reasonCode) {
+        this.roundStatus = RoundStatus.CLOSED;
         this.endedAt = LocalDateTime.now();
         this.roundEndReasonCode = reasonCode;
     }

--- a/src/main/java/com/sollite/account/domain/entity/SimulationRound.java
+++ b/src/main/java/com/sollite/account/domain/entity/SimulationRound.java
@@ -31,8 +31,8 @@ public class SimulationRound {
     @Column(name = "initial_seed_amount", nullable = false, precision = 19, scale = 4)
     private BigDecimal initialSeedAmount;
 
-    @Column(name = "reset_reason_code", length = 50)
-    private String resetReasonCode;
+    @Column(name = "round_end_reason_code", length = 50)
+    private String roundEndReasonCode;
 
     @Column(name = "round_status", nullable = false, length = 20)
     private String roundStatus = "ACTIVE";
@@ -53,5 +53,11 @@ public class SimulationRound {
         this.roundNo = roundNo;
         this.initialSeedAmount = initialSeedAmount;
         this.startedAt = LocalDateTime.now();
+    }
+
+    public void close(String reasonCode) {
+        this.roundStatus = "CLOSED";
+        this.endedAt = LocalDateTime.now();
+        this.roundEndReasonCode = reasonCode;
     }
 }

--- a/src/main/java/com/sollite/account/domain/enums/RoundEndReasonCode.java
+++ b/src/main/java/com/sollite/account/domain/enums/RoundEndReasonCode.java
@@ -1,0 +1,6 @@
+package com.sollite.account.domain.enums;
+
+public enum RoundEndReasonCode {
+    RESET,
+    ACCOUNT_CLOSED
+}

--- a/src/main/java/com/sollite/account/domain/enums/RoundStatus.java
+++ b/src/main/java/com/sollite/account/domain/enums/RoundStatus.java
@@ -1,0 +1,6 @@
+package com.sollite.account.domain.enums;
+
+public enum RoundStatus {
+    ACTIVE,
+    CLOSED
+}

--- a/src/main/java/com/sollite/account/domain/repository/AccountRepository.java
+++ b/src/main/java/com/sollite/account/domain/repository/AccountRepository.java
@@ -1,13 +1,21 @@
 package com.sollite.account.domain.repository;
 
 import com.sollite.account.domain.entity.Account;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
     Optional<Account> findByUser_UserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from Account a where a.user.userId = :userId")
+    Optional<Account> findByUserIdForUpdate(@Param("userId") Long userId);
 
     boolean existsByUser_UserId(Long userId);
 

--- a/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
+++ b/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
@@ -1,17 +1,15 @@
 package com.sollite.account.domain.repository;
 
 import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.RoundStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface SimulationRoundRepository extends JpaRepository<SimulationRound, Long> {
 
-    Optional<SimulationRound> findByAccount_AccountIdAndRoundStatus(Long accountId, String roundStatus);
-
-    List<SimulationRound> findAllByAccount_AccountIdOrderByRoundNoAsc(Long accountId);
+    Optional<SimulationRound> findByAccount_AccountIdAndRoundStatus(Long accountId, RoundStatus roundStatus);
 
     @Transactional
     void deleteByAccount_AccountId(Long accountId);

--- a/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
+++ b/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
@@ -4,11 +4,14 @@ import com.sollite.account.domain.entity.SimulationRound;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SimulationRoundRepository extends JpaRepository<SimulationRound, Long> {
 
     Optional<SimulationRound> findByAccount_AccountIdAndRoundStatus(Long accountId, String roundStatus);
+
+    List<SimulationRound> findAllByAccount_AccountIdOrderByRoundNoAsc(Long accountId);
 
     @Transactional
     void deleteByAccount_AccountId(Long accountId);

--- a/src/main/java/com/sollite/account/dto/AccountResetRequest.java
+++ b/src/main/java/com/sollite/account/dto/AccountResetRequest.java
@@ -1,0 +1,11 @@
+package com.sollite.account.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record AccountResetRequest(
+        @NotBlank(message = "계좌 비밀번호는 필수입니다")
+        @Pattern(regexp = "^\\d{4}$", message = "계좌 비밀번호는 숫자 4자리입니다")
+        String accountPin
+) {
+}

--- a/src/main/java/com/sollite/account/dto/AccountResetResponse.java
+++ b/src/main/java/com/sollite/account/dto/AccountResetResponse.java
@@ -1,0 +1,7 @@
+package com.sollite.account.dto;
+
+public record AccountResetResponse(
+        String message,
+        Integer roundNo
+) {
+}

--- a/src/main/java/com/sollite/account/exception/AccountErrorCode.java
+++ b/src/main/java/com/sollite/account/exception/AccountErrorCode.java
@@ -10,6 +10,7 @@ public enum AccountErrorCode implements ErrorCode {
 
     ACCOUNT_ALREADY_EXISTS(409, "이미 계좌가 개설되어 있습니다"),
     ACCOUNT_NOT_FOUND(404, "계좌가 존재하지 않습니다"),
+    ACTIVE_ROUND_NOT_FOUND(404, "진행 중인 시뮬레이션 라운드가 없습니다"),
     INVALID_PIN(403, "계좌 비밀번호가 올바르지 않습니다"),
     INVALID_PIN_FORMAT(400, "계좌 비밀번호는 숫자 4자리여야 합니다"),
     PIN_ATTEMPT_EXCEEDED(429, "계좌 비밀번호 시도 횟수를 초과했습니다"),

--- a/src/main/java/com/sollite/account/service/AccountService.java
+++ b/src/main/java/com/sollite/account/service/AccountService.java
@@ -6,6 +6,7 @@ import com.sollite.account.domain.enums.InvestmentType;
 import com.sollite.account.domain.repository.AccountRepository;
 import com.sollite.account.domain.repository.SimulationRoundRepository;
 import com.sollite.account.dto.AccountInfoResponse;
+import com.sollite.account.dto.AccountResetResponse;
 import com.sollite.account.exception.AccountErrorCode;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.user.domain.entity.User;
@@ -25,6 +26,9 @@ import java.util.concurrent.ThreadLocalRandom;
 public class AccountService {
 
     private static final BigDecimal SEED_MONEY = new BigDecimal("100000000");
+    private static final String ACTIVE_ROUND_STATUS = "ACTIVE";
+    private static final String RESET_REASON_CODE = "RESET";
+    private static final String ACCOUNT_CLOSED_REASON_CODE = "ACCOUNT_CLOSED";
 
     private final AccountRepository accountRepository;
     private final SimulationRoundRepository simulationRoundRepository;
@@ -117,8 +121,40 @@ public class AccountService {
     }
 
     @Transactional
+    public AccountResetResponse resetAccount(Long userId, String accountPin) {
+        Account account = accountRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+
+        if (!account.isActive()) {
+            throw new BusinessException(AccountErrorCode.ACCOUNT_NOT_ACTIVE);
+        }
+
+        if (!passwordEncoder.matches(accountPin, account.getAccountPinHash())) {
+            throw new BusinessException(AccountErrorCode.INVALID_PIN);
+        }
+
+        SimulationRound currentRound = simulationRoundRepository
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), ACTIVE_ROUND_STATUS)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+
+        currentRound.close(RESET_REASON_CODE);
+
+        SimulationRound newRound = SimulationRound.builder()
+                .account(account)
+                .roundNo(currentRound.getRoundNo() + 1)
+                .initialSeedAmount(SEED_MONEY)
+                .build();
+
+        simulationRoundRepository.save(newRound);
+
+        // TODO: balance 도메인 구현 후 새 라운드 현금 잔고를 1억원으로 초기화한다.
+
+        return new AccountResetResponse("시뮬레이션이 초기화되었습니다.", newRound.getRoundNo());
+    }
+
+    @Transactional
     public void closeAccount(Long userId, String accountPin) {
-        Account account = accountRepository.findByUser_UserId(userId)
+        Account account = accountRepository.findByUserIdForUpdate(userId)
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACCOUNT_NOT_FOUND));
 
         if (!account.isActive()) {
@@ -133,6 +169,11 @@ public class AccountService {
         // TODO: 보유 주식/ETF 있으면 폐쇄 불가 — holdings 도메인 구현 후 추가 (issue #15)
         // TODO: 미체결 주문 있으면 폐쇄 불가 — order 도메인 구현 후 추가 (issue #15)
 
+        SimulationRound currentRound = simulationRoundRepository
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), ACTIVE_ROUND_STATUS)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+
+        currentRound.close(ACCOUNT_CLOSED_REASON_CODE);
         account.close();
     }
 

--- a/src/main/java/com/sollite/account/service/AccountService.java
+++ b/src/main/java/com/sollite/account/service/AccountService.java
@@ -3,6 +3,8 @@ package com.sollite.account.service;
 import com.sollite.account.domain.entity.Account;
 import com.sollite.account.domain.entity.SimulationRound;
 import com.sollite.account.domain.enums.InvestmentType;
+import com.sollite.account.domain.enums.RoundEndReasonCode;
+import com.sollite.account.domain.enums.RoundStatus;
 import com.sollite.account.domain.repository.AccountRepository;
 import com.sollite.account.domain.repository.SimulationRoundRepository;
 import com.sollite.account.dto.AccountInfoResponse;
@@ -26,9 +28,6 @@ import java.util.concurrent.ThreadLocalRandom;
 public class AccountService {
 
     private static final BigDecimal SEED_MONEY = new BigDecimal("100000000");
-    private static final String ACTIVE_ROUND_STATUS = "ACTIVE";
-    private static final String RESET_REASON_CODE = "RESET";
-    private static final String ACCOUNT_CLOSED_REASON_CODE = "ACCOUNT_CLOSED";
 
     private final AccountRepository accountRepository;
     private final SimulationRoundRepository simulationRoundRepository;
@@ -134,10 +133,10 @@ public class AccountService {
         }
 
         SimulationRound currentRound = simulationRoundRepository
-                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), ACTIVE_ROUND_STATUS)
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
 
-        currentRound.close(RESET_REASON_CODE);
+        currentRound.close(RoundEndReasonCode.RESET);
 
         SimulationRound newRound = SimulationRound.builder()
                 .account(account)
@@ -170,10 +169,10 @@ public class AccountService {
         // TODO: 미체결 주문 있으면 폐쇄 불가 — order 도메인 구현 후 추가 (issue #15)
 
         SimulationRound currentRound = simulationRoundRepository
-                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), ACTIVE_ROUND_STATUS)
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
 
-        currentRound.close(ACCOUNT_CLOSED_REASON_CODE);
+        currentRound.close(RoundEndReasonCode.ACCOUNT_CLOSED);
         account.close();
     }
 

--- a/src/main/resources/db/migration/V4__rename_simulation_round_end_reason.sql
+++ b/src/main/resources/db/migration/V4__rename_simulation_round_end_reason.sql
@@ -1,0 +1,2 @@
+ALTER TABLE simulation_rounds
+RENAME COLUMN reset_reason_code TO round_end_reason_code;

--- a/src/test/java/com/sollite/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/sollite/account/controller/AccountControllerTest.java
@@ -1,6 +1,8 @@
 package com.sollite.account.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sollite.account.dto.AccountResetRequest;
+import com.sollite.account.dto.AccountResetResponse;
 import com.sollite.account.dto.PinChangeRequest;
 import com.sollite.account.dto.PinVerifyRequest;
 import com.sollite.account.exception.AccountErrorCode;
@@ -21,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -87,6 +90,43 @@ class AccountControllerTest {
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.code").value("INVALID_PIN"))
                     .andExpect(jsonPath("$.message").value("계좌 비밀번호가 올바르지 않습니다"));
+        }
+    }
+
+    @Nested
+    @DisplayName("시뮬레이션 리셋 API")
+    class ResetAccount {
+
+        @Test
+        @DisplayName("리셋 성공 시 200")
+        @WithMockUser(username = "1")
+        void resetAccount_success() throws Exception {
+            AccountResetRequest request = new AccountResetRequest("1234");
+            given(accountService.resetAccount(1L, "1234"))
+                    .willReturn(new AccountResetResponse("시뮬레이션이 초기화되었습니다.", 2));
+
+            mockMvc.perform(post("/api/accounts/reset")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("시뮬레이션이 초기화되었습니다."))
+                    .andExpect(jsonPath("$.roundNo").value(2));
+        }
+
+        @Test
+        @DisplayName("PIN 형식 오류 시 400")
+        @WithMockUser(username = "1")
+        void resetAccount_fail_invalidPinFormat() throws Exception {
+            AccountResetRequest request = new AccountResetRequest("12ab");
+
+            mockMvc.perform(post("/api/accounts/reset")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                    .andExpect(jsonPath("$.errors.accountPin").value("계좌 비밀번호는 숫자 4자리입니다"));
         }
     }
 }

--- a/src/test/java/com/sollite/account/integration/AccountIntegrationTest.java
+++ b/src/test/java/com/sollite/account/integration/AccountIntegrationTest.java
@@ -6,10 +6,13 @@ import com.sollite.account.domain.entity.Account;
 import com.sollite.account.domain.entity.SimulationRound;
 import com.sollite.account.domain.enums.AccountStatus;
 import com.sollite.account.domain.enums.InvestmentType;
+import com.sollite.account.domain.enums.RoundEndReasonCode;
+import com.sollite.account.domain.enums.RoundStatus;
 import com.sollite.account.domain.repository.AccountRepository;
 import com.sollite.account.domain.repository.SimulationRoundRepository;
 import com.sollite.account.dto.AccountCloseRequest;
 import com.sollite.account.dto.AccountResetRequest;
+import jakarta.persistence.EntityManager;
 import com.sollite.user.domain.repository.UserConsentRepository;
 import com.sollite.user.domain.repository.UserRepository;
 import com.sollite.user.dto.LoginRequest;
@@ -58,6 +61,9 @@ class AccountIntegrationTest {
     private SimulationRoundRepository simulationRoundRepository;
 
     @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
     private UserConsentRepository userConsentRepository;
 
     @Autowired
@@ -94,8 +100,7 @@ class AccountIntegrationTest {
                 .andExpect(jsonPath("$.roundNo").value(2));
 
         Account account = getAccount();
-        List<SimulationRound> rounds = simulationRoundRepository
-                .findAllByAccount_AccountIdOrderByRoundNoAsc(account.getAccountId());
+        List<SimulationRound> rounds = findRounds(account.getAccountId());
 
         assertThat(account.getAccountStatus()).isEqualTo(AccountStatus.ACTIVE);
         assertThat(rounds).hasSize(2);
@@ -104,12 +109,12 @@ class AccountIntegrationTest {
         SimulationRound secondRound = rounds.get(1);
 
         assertThat(firstRound.getRoundNo()).isEqualTo(1);
-        assertThat(firstRound.getRoundStatus()).isEqualTo("CLOSED");
-        assertThat(firstRound.getRoundEndReasonCode()).isEqualTo("RESET");
+        assertThat(firstRound.getRoundStatus()).isEqualTo(RoundStatus.CLOSED);
+        assertThat(firstRound.getRoundEndReasonCode()).isEqualTo(RoundEndReasonCode.RESET);
         assertThat(firstRound.getEndedAt()).isNotNull();
 
         assertThat(secondRound.getRoundNo()).isEqualTo(2);
-        assertThat(secondRound.getRoundStatus()).isEqualTo("ACTIVE");
+        assertThat(secondRound.getRoundStatus()).isEqualTo(RoundStatus.ACTIVE);
         assertThat(secondRound.getRoundEndReasonCode()).isNull();
         assertThat(secondRound.getEndedAt()).isNull();
         assertThat(secondRound.getInitialSeedAmount()).isEqualByComparingTo(new BigDecimal("100000000"));
@@ -129,12 +134,11 @@ class AccountIntegrationTest {
                 .andExpect(jsonPath("$.code").value("INVALID_PIN"));
 
         Account account = getAccount();
-        List<SimulationRound> rounds = simulationRoundRepository
-                .findAllByAccount_AccountIdOrderByRoundNoAsc(account.getAccountId());
+        List<SimulationRound> rounds = findRounds(account.getAccountId());
 
         assertThat(rounds).hasSize(1);
         assertThat(rounds.get(0).getRoundNo()).isEqualTo(1);
-        assertThat(rounds.get(0).getRoundStatus()).isEqualTo("ACTIVE");
+        assertThat(rounds.get(0).getRoundStatus()).isEqualTo(RoundStatus.ACTIVE);
         assertThat(rounds.get(0).getRoundEndReasonCode()).isNull();
     }
 
@@ -152,13 +156,12 @@ class AccountIntegrationTest {
                 .andExpect(jsonPath("$.message").value("계좌가 폐쇄되었습니다."));
 
         Account account = getAccount();
-        List<SimulationRound> rounds = simulationRoundRepository
-                .findAllByAccount_AccountIdOrderByRoundNoAsc(account.getAccountId());
+        List<SimulationRound> rounds = findRounds(account.getAccountId());
 
         assertThat(account.getAccountStatus()).isEqualTo(AccountStatus.CLOSED);
         assertThat(rounds).hasSize(1);
-        assertThat(rounds.get(0).getRoundStatus()).isEqualTo("CLOSED");
-        assertThat(rounds.get(0).getRoundEndReasonCode()).isEqualTo("ACCOUNT_CLOSED");
+        assertThat(rounds.get(0).getRoundStatus()).isEqualTo(RoundStatus.CLOSED);
+        assertThat(rounds.get(0).getRoundEndReasonCode()).isEqualTo(RoundEndReasonCode.ACCOUNT_CLOSED);
         assertThat(rounds.get(0).getEndedAt()).isNotNull();
     }
 
@@ -199,6 +202,18 @@ class AccountIntegrationTest {
 
         return accountRepository.findByUser_UserId(userId)
                 .orElseThrow();
+    }
+
+    private List<SimulationRound> findRounds(Long accountId) {
+        entityManager.clear();
+        return entityManager.createQuery("""
+                        select simulationRound
+                        from SimulationRound simulationRound
+                        where simulationRound.account.accountId = :accountId
+                        order by simulationRound.roundNo asc
+                        """, SimulationRound.class)
+                .setParameter("accountId", accountId)
+                .getResultList();
     }
 
     private void deleteTestData() {

--- a/src/test/java/com/sollite/account/integration/AccountIntegrationTest.java
+++ b/src/test/java/com/sollite/account/integration/AccountIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.sollite.account.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.AccountStatus;
+import com.sollite.account.domain.enums.InvestmentType;
+import com.sollite.account.domain.repository.AccountRepository;
+import com.sollite.account.domain.repository.SimulationRoundRepository;
+import com.sollite.account.dto.AccountCloseRequest;
+import com.sollite.account.dto.AccountResetRequest;
+import com.sollite.user.domain.repository.UserConsentRepository;
+import com.sollite.user.domain.repository.UserRepository;
+import com.sollite.user.dto.LoginRequest;
+import com.sollite.user.dto.SignupRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class AccountIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private SimulationRoundRepository simulationRoundRepository;
+
+    @Autowired
+    private UserConsentRepository userConsentRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private static final String TEST_EMAIL = "account-integration@test.com";
+    private static final String TEST_PASSWORD = "Test1234!";
+    private static final String TEST_ACCOUNT_PIN = "1234";
+
+    @BeforeEach
+    void setup() {
+        deleteTestData();
+        redisTemplate.opsForValue().set("email_verified:" + TEST_EMAIL, "true");
+    }
+
+    @AfterEach
+    void cleanup() {
+        redisTemplate.delete("email_verified:" + TEST_EMAIL);
+        deleteTestData();
+    }
+
+    @Test
+    @DisplayName("통합 테스트 - 계좌 리셋 성공 시 이전 라운드 종료 후 새 라운드 생성")
+    void resetAccount_success() throws Exception {
+        signup();
+        String accessToken = loginAndGetAccessToken();
+
+        mockMvc.perform(post("/api/accounts/reset")
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new AccountResetRequest(TEST_ACCOUNT_PIN))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("시뮬레이션이 초기화되었습니다."))
+                .andExpect(jsonPath("$.roundNo").value(2));
+
+        Account account = getAccount();
+        List<SimulationRound> rounds = simulationRoundRepository
+                .findAllByAccount_AccountIdOrderByRoundNoAsc(account.getAccountId());
+
+        assertThat(account.getAccountStatus()).isEqualTo(AccountStatus.ACTIVE);
+        assertThat(rounds).hasSize(2);
+
+        SimulationRound firstRound = rounds.get(0);
+        SimulationRound secondRound = rounds.get(1);
+
+        assertThat(firstRound.getRoundNo()).isEqualTo(1);
+        assertThat(firstRound.getRoundStatus()).isEqualTo("CLOSED");
+        assertThat(firstRound.getRoundEndReasonCode()).isEqualTo("RESET");
+        assertThat(firstRound.getEndedAt()).isNotNull();
+
+        assertThat(secondRound.getRoundNo()).isEqualTo(2);
+        assertThat(secondRound.getRoundStatus()).isEqualTo("ACTIVE");
+        assertThat(secondRound.getRoundEndReasonCode()).isNull();
+        assertThat(secondRound.getEndedAt()).isNull();
+        assertThat(secondRound.getInitialSeedAmount()).isEqualByComparingTo(new BigDecimal("100000000"));
+    }
+
+    @Test
+    @DisplayName("통합 테스트 - 계좌 리셋 실패 시 라운드 유지")
+    void resetAccount_fail_wrongPin() throws Exception {
+        signup();
+        String accessToken = loginAndGetAccessToken();
+
+        mockMvc.perform(post("/api/accounts/reset")
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new AccountResetRequest("9999"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("INVALID_PIN"));
+
+        Account account = getAccount();
+        List<SimulationRound> rounds = simulationRoundRepository
+                .findAllByAccount_AccountIdOrderByRoundNoAsc(account.getAccountId());
+
+        assertThat(rounds).hasSize(1);
+        assertThat(rounds.get(0).getRoundNo()).isEqualTo(1);
+        assertThat(rounds.get(0).getRoundStatus()).isEqualTo("ACTIVE");
+        assertThat(rounds.get(0).getRoundEndReasonCode()).isNull();
+    }
+
+    @Test
+    @DisplayName("통합 테스트 - 계좌 해지 성공 시 계좌와 현재 라운드가 함께 종료")
+    void closeAccount_success() throws Exception {
+        signup();
+        String accessToken = loginAndGetAccessToken();
+
+        mockMvc.perform(delete("/api/accounts")
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new AccountCloseRequest(TEST_ACCOUNT_PIN))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("계좌가 폐쇄되었습니다."));
+
+        Account account = getAccount();
+        List<SimulationRound> rounds = simulationRoundRepository
+                .findAllByAccount_AccountIdOrderByRoundNoAsc(account.getAccountId());
+
+        assertThat(account.getAccountStatus()).isEqualTo(AccountStatus.CLOSED);
+        assertThat(rounds).hasSize(1);
+        assertThat(rounds.get(0).getRoundStatus()).isEqualTo("CLOSED");
+        assertThat(rounds.get(0).getRoundEndReasonCode()).isEqualTo("ACCOUNT_CLOSED");
+        assertThat(rounds.get(0).getEndedAt()).isNotNull();
+    }
+
+    private void signup() throws Exception {
+        SignupRequest signupRequest = new SignupRequest(
+                TEST_EMAIL, TEST_PASSWORD, TEST_PASSWORD,
+                "계좌통합테스트", "010-0000-1234", true, true,
+                InvestmentType.BALANCED, TEST_ACCOUNT_PIN
+        );
+
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupRequest)))
+                .andExpect(status().isCreated());
+    }
+
+    private String loginAndGetAccessToken() throws Exception {
+        LoginRequest loginRequest = new LoginRequest(TEST_EMAIL, TEST_PASSWORD, false);
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(loginResult.getResponse().getContentAsString());
+        return body.get("accessToken").asText();
+    }
+
+    private String bearerToken(String accessToken) {
+        return "Bearer " + accessToken;
+    }
+
+    private Account getAccount() {
+        Long userId = userRepository.findByEmail(TEST_EMAIL)
+                .orElseThrow()
+                .getUserId();
+
+        return accountRepository.findByUser_UserId(userId)
+                .orElseThrow();
+    }
+
+    private void deleteTestData() {
+        userRepository.findByEmail(TEST_EMAIL).ifPresent(user -> {
+            accountRepository.findByUser_UserId(user.getUserId()).ifPresent(account -> {
+                simulationRoundRepository.deleteByAccount_AccountId(account.getAccountId());
+                accountRepository.delete(account);
+            });
+            userConsentRepository.deleteById(user.getUserId());
+            userRepository.delete(user);
+        });
+    }
+}

--- a/src/test/java/com/sollite/account/service/AccountServiceTest.java
+++ b/src/test/java/com/sollite/account/service/AccountServiceTest.java
@@ -3,6 +3,8 @@ package com.sollite.account.service;
 import com.sollite.account.domain.entity.Account;
 import com.sollite.account.domain.entity.SimulationRound;
 import com.sollite.account.domain.enums.InvestmentType;
+import com.sollite.account.domain.enums.RoundEndReasonCode;
+import com.sollite.account.domain.enums.RoundStatus;
 import com.sollite.account.domain.repository.AccountRepository;
 import com.sollite.account.domain.repository.SimulationRoundRepository;
 import com.sollite.account.dto.AccountInfoResponse;
@@ -298,15 +300,15 @@ class AccountServiceTest {
 
             given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
             given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
-            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, RoundStatus.ACTIVE))
                     .willReturn(Optional.of(currentRound));
             given(simulationRoundRepository.save(any(SimulationRound.class))).willAnswer(i -> i.getArgument(0));
 
             AccountResetResponse response = accountService.resetAccount(1L, "1234");
 
             assertThat(response.roundNo()).isEqualTo(2);
-            assertThat(currentRound.getRoundStatus()).isEqualTo("CLOSED");
-            assertThat(currentRound.getRoundEndReasonCode()).isEqualTo("RESET");
+            assertThat(currentRound.getRoundStatus()).isEqualTo(RoundStatus.CLOSED);
+            assertThat(currentRound.getRoundEndReasonCode()).isEqualTo(RoundEndReasonCode.RESET);
             assertThat(currentRound.getEndedAt()).isNotNull();
 
             verify(simulationRoundRepository).save(argThat(newRound ->
@@ -355,7 +357,7 @@ class AccountServiceTest {
 
             given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
             given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
-            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, RoundStatus.ACTIVE))
                     .willReturn(Optional.empty());
 
             assertThatThrownBy(() -> accountService.resetAccount(1L, "1234"))
@@ -389,14 +391,14 @@ class AccountServiceTest {
             SimulationRound currentRound = createSimulationRound(account, 1);
             given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
             given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
-            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, RoundStatus.ACTIVE))
                     .willReturn(Optional.of(currentRound));
 
             accountService.closeAccount(1L, "1234");
 
             assertThat(account.isActive()).isFalse();
-            assertThat(currentRound.getRoundStatus()).isEqualTo("CLOSED");
-            assertThat(currentRound.getRoundEndReasonCode()).isEqualTo("ACCOUNT_CLOSED");
+            assertThat(currentRound.getRoundStatus()).isEqualTo(RoundStatus.CLOSED);
+            assertThat(currentRound.getRoundEndReasonCode()).isEqualTo(RoundEndReasonCode.ACCOUNT_CLOSED);
             assertThat(currentRound.getEndedAt()).isNotNull();
         }
 
@@ -423,7 +425,7 @@ class AccountServiceTest {
 
             given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
             given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
-            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, RoundStatus.ACTIVE))
                     .willReturn(Optional.empty());
 
             assertThatThrownBy(() -> accountService.closeAccount(1L, "1234"))

--- a/src/test/java/com/sollite/account/service/AccountServiceTest.java
+++ b/src/test/java/com/sollite/account/service/AccountServiceTest.java
@@ -1,10 +1,12 @@
 package com.sollite.account.service;
 
 import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
 import com.sollite.account.domain.enums.InvestmentType;
 import com.sollite.account.domain.repository.AccountRepository;
 import com.sollite.account.domain.repository.SimulationRoundRepository;
 import com.sollite.account.dto.AccountInfoResponse;
+import com.sollite.account.dto.AccountResetResponse;
 import com.sollite.account.exception.AccountErrorCode;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.user.domain.entity.User;
@@ -19,7 +21,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 
@@ -65,6 +69,14 @@ class AccountServiceTest {
                 .accountName("종합계좌 홍길동")
                 .accountPinHash("encodedPin")
                 .investmentTendency(InvestmentType.BALANCED)
+                .build();
+    }
+
+    private SimulationRound createSimulationRound(Account account, int roundNo) {
+        return SimulationRound.builder()
+                .account(account)
+                .roundNo(roundNo)
+                .initialSeedAmount(new BigDecimal("100000000"))
                 .build();
     }
 
@@ -273,6 +285,98 @@ class AccountServiceTest {
     }
 
     @Nested
+    @DisplayName("시뮬레이션 리셋")
+    class ResetAccount {
+
+        @Test
+        @DisplayName("리셋 성공")
+        void resetAccount_success() {
+            User user = createUser();
+            Account account = createAccount(user);
+            ReflectionTestUtils.setField(account, "accountId", 1L);
+            SimulationRound currentRound = createSimulationRound(account, 1);
+
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
+            given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+                    .willReturn(Optional.of(currentRound));
+            given(simulationRoundRepository.save(any(SimulationRound.class))).willAnswer(i -> i.getArgument(0));
+
+            AccountResetResponse response = accountService.resetAccount(1L, "1234");
+
+            assertThat(response.roundNo()).isEqualTo(2);
+            assertThat(currentRound.getRoundStatus()).isEqualTo("CLOSED");
+            assertThat(currentRound.getRoundEndReasonCode()).isEqualTo("RESET");
+            assertThat(currentRound.getEndedAt()).isNotNull();
+
+            verify(simulationRoundRepository).save(argThat(newRound ->
+                    newRound.getAccount() == account
+                            && newRound.getRoundNo().equals(2)
+                            && newRound.getInitialSeedAmount().compareTo(new BigDecimal("100000000")) == 0
+            ));
+        }
+
+        @Test
+        @DisplayName("리셋 실패 - PIN 불일치")
+        void resetAccount_fail_wrongPin() {
+            User user = createUser();
+            Account account = createAccount(user);
+
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
+            given(passwordEncoder.matches("9999", "encodedPin")).willReturn(false);
+
+            assertThatThrownBy(() -> accountService.resetAccount(1L, "9999"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AccountErrorCode.INVALID_PIN));
+        }
+
+        @Test
+        @DisplayName("리셋 실패 - 비활성 계좌")
+        void resetAccount_fail_inactiveAccount() {
+            User user = createUser();
+            Account account = createAccount(user);
+            account.close();
+
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
+
+            assertThatThrownBy(() -> accountService.resetAccount(1L, "1234"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AccountErrorCode.ACCOUNT_NOT_ACTIVE));
+        }
+
+        @Test
+        @DisplayName("리셋 실패 - 활성 라운드 없음")
+        void resetAccount_fail_noActiveRound() {
+            User user = createUser();
+            Account account = createAccount(user);
+            ReflectionTestUtils.setField(account, "accountId", 1L);
+
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
+            given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> accountService.resetAccount(1L, "1234"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("리셋 실패 - 계좌 없음")
+        void resetAccount_fail_noAccount() {
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> accountService.resetAccount(1L, "1234"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AccountErrorCode.ACCOUNT_NOT_FOUND));
+        }
+    }
+
+    @Nested
     @DisplayName("계좌 폐쇄")
     class CloseAccount {
 
@@ -281,12 +385,19 @@ class AccountServiceTest {
         void closeAccount_success() {
             User user = createUser();
             Account account = createAccount(user);
-            given(accountRepository.findByUser_UserId(1L)).willReturn(Optional.of(account));
+            ReflectionTestUtils.setField(account, "accountId", 1L);
+            SimulationRound currentRound = createSimulationRound(account, 1);
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
             given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+                    .willReturn(Optional.of(currentRound));
 
             accountService.closeAccount(1L, "1234");
 
             assertThat(account.isActive()).isFalse();
+            assertThat(currentRound.getRoundStatus()).isEqualTo("CLOSED");
+            assertThat(currentRound.getRoundEndReasonCode()).isEqualTo("ACCOUNT_CLOSED");
+            assertThat(currentRound.getEndedAt()).isNotNull();
         }
 
         @Test
@@ -294,7 +405,7 @@ class AccountServiceTest {
         void closeAccount_fail_wrongPin() {
             User user = createUser();
             Account account = createAccount(user);
-            given(accountRepository.findByUser_UserId(1L)).willReturn(Optional.of(account));
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
             given(passwordEncoder.matches("9999", "encodedPin")).willReturn(false);
 
             assertThatThrownBy(() -> accountService.closeAccount(1L, "9999"))
@@ -304,12 +415,30 @@ class AccountServiceTest {
         }
 
         @Test
+        @DisplayName("계좌 폐쇄 실패 - 활성 라운드 없음")
+        void closeAccount_fail_noActiveRound() {
+            User user = createUser();
+            Account account = createAccount(user);
+            ReflectionTestUtils.setField(account, "accountId", 1L);
+
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
+            given(passwordEncoder.matches("1234", "encodedPin")).willReturn(true);
+            given(simulationRoundRepository.findByAccount_AccountIdAndRoundStatus(1L, "ACTIVE"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> accountService.closeAccount(1L, "1234"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+        }
+
+        @Test
         @DisplayName("계좌 폐쇄 실패 - 이미 폐쇄된 계좌")
         void closeAccount_fail_alreadyClosed() {
             User user = createUser();
             Account account = createAccount(user);
             account.close();
-            given(accountRepository.findByUser_UserId(1L)).willReturn(Optional.of(account));
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.of(account));
 
             assertThatThrownBy(() -> accountService.closeAccount(1L, "1234"))
                     .isInstanceOf(BusinessException.class)
@@ -320,7 +449,7 @@ class AccountServiceTest {
         @Test
         @DisplayName("계좌 폐쇄 실패 - 계좌 없음")
         void closeAccount_fail_noAccount() {
-            given(accountRepository.findByUser_UserId(1L)).willReturn(Optional.empty());
+            given(accountRepository.findByUserIdForUpdate(1L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> accountService.closeAccount(1L, "1234"))
                     .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## 연관된 이슈

- 없음

## 작업 내용

- 계좌 리셋 API를 추가하고 현재 회차를 종료한 뒤 새 회차를 생성하도록 구현했습니다.
- 계좌 해지 시 현재 활성 회차를 ACCOUNT_CLOSED 사유로 종료하도록 반영했습니다.
- simulation_rounds 종료 사유 컬럼을 round_end_reason_code로 rename하는 Flyway 마이그레이션을 추가했습니다.
- 서비스, 컨트롤러, 계좌 통합 테스트를 추가했습니다.

### 스크린샷 (선택)

- 없음

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [x] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

- reset과 closeAccount가 동일한 account row lock을 사용하도록 맞췄습니다. 동시성 처리 방향이 적절한지 봐주시면 됩니다.