### PR TITLE
feat(market): 재무정보/투자의견/투자자 매매동향 API 구현

### DIFF
--- a/src/main/java/com/sollite/market/controller/MarketController.java
+++ b/src/main/java/com/sollite/market/controller/MarketController.java
@@ -4,6 +4,7 @@ import com.sollite.market.dto.*;
 import com.sollite.market.service.MarketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -42,5 +43,20 @@ public class MarketController {
             @PathVariable String stockCode,
             @RequestParam(defaultValue = "1") int ncnt) {
         return ResponseEntity.ok(marketService.getMinuteChart(stockCode, ncnt));
+    }
+
+    @GetMapping("/stocks/{stockCode}/finance")
+    public ResponseEntity<FinanceResponse> getFinance(@PathVariable String stockCode) {
+        return ResponseEntity.ok(marketService.getFinance(stockCode));
+    }
+
+    @GetMapping("/stocks/{stockCode}/opinion")
+    public ResponseEntity<OpinionResponse> getOpinion(@PathVariable String stockCode) {
+        return ResponseEntity.ok(marketService.getOpinion((stockCode)));
+    }
+
+    @GetMapping("/stocks/{stockCode}/investor")
+    public ResponseEntity<InvestorResponse> getInvestor(@PathVariable String stockCode) {
+        return ResponseEntity.ok(marketService.getInvestor(stockCode));
     }
 }

--- a/src/main/java/com/sollite/market/controller/MarketController.java
+++ b/src/main/java/com/sollite/market/controller/MarketController.java
@@ -4,7 +4,6 @@ import com.sollite.market.dto.*;
 import com.sollite.market.service.MarketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -52,7 +51,7 @@ public class MarketController {
 
     @GetMapping("/stocks/{stockCode}/opinion")
     public ResponseEntity<OpinionResponse> getOpinion(@PathVariable String stockCode) {
-        return ResponseEntity.ok(marketService.getOpinion((stockCode)));
+        return ResponseEntity.ok(marketService.getOpinion(stockCode));
     }
 
     @GetMapping("/stocks/{stockCode}/investor")

--- a/src/main/java/com/sollite/market/dto/FinanceResponse.java
+++ b/src/main/java/com/sollite/market/dto/FinanceResponse.java
@@ -1,0 +1,14 @@
+package com.sollite.market.dto;
+
+public record FinanceResponse(
+        String stockCode,       // 종목코드
+        String marketCap,       // 시가총액 (단위: 억원)
+        String per,             // PER (주가수익비율)
+        String pbr,             // PBR (주가순자산비율)
+        String eps,             // EPS (주당순이익)
+        String bps,             // BPS (주당순자산가치)
+        String capital,         // 자본금 (단위: 억원)
+        String roe,             // ROE (자기자본이익률, %)
+        String foreignRatio,    // 외국인 보유비율 (%)
+        String settlementYm     // 결산년월 (예: 202512)
+) {}

--- a/src/main/java/com/sollite/market/dto/InvestorResponse.java
+++ b/src/main/java/com/sollite/market/dto/InvestorResponse.java
@@ -1,0 +1,10 @@
+package com.sollite.market.dto;
+
+public record InvestorResponse(
+        String stockCode,
+        String date,            // 기준일자
+        int close,              // 종가
+        long foreignNetBuy,     // 외인계 순매수
+        long institutionNetBuy, // 기관 순매수
+        long individualNetBuy   // 개인 순매수
+) {}

--- a/src/main/java/com/sollite/market/dto/LsFinanceRes.java
+++ b/src/main/java/com/sollite/market/dto/LsFinanceRes.java
@@ -1,0 +1,23 @@
+package com.sollite.market.dto;
+
+public record LsFinanceRes(
+        String rsp_cd,
+        String rsp_msg,
+        LsFinanceBlock  t3320OutBlock,
+        LsFinanceBlock1 t3320OutBlock1
+) {
+    public record LsFinanceBlock(
+            String sigavalue,
+            String capital,
+            String foreignratio
+    ) {}
+
+    public record LsFinanceBlock1(
+            String per,
+            String eps,
+            String pbr,
+            String bps,
+            String roe,
+            String gsym
+    ) {}
+}

--- a/src/main/java/com/sollite/market/dto/LsInvestorRes.java
+++ b/src/main/java/com/sollite/market/dto/LsInvestorRes.java
@@ -1,0 +1,17 @@
+package com.sollite.market.dto;
+
+import java.util.List;
+
+public record LsInvestorRes(
+        String rsp_cd,
+        String rsp_msg,
+        List<LsInvestorItem> t1717OutBlock
+) {
+    public record LsInvestorItem(
+            String date,
+            int close,
+            long tjj0008_vol,
+            long tjj0016_vol,
+            long tjj0018_vol
+    ) {}
+}

--- a/src/main/java/com/sollite/market/dto/LsOpinionRes.java
+++ b/src/main/java/com/sollite/market/dto/LsOpinionRes.java
@@ -1,0 +1,20 @@
+package com.sollite.market.dto;
+
+import java.util.List;
+
+public record LsOpinionRes (
+        String rsp_cd,
+        String rsp_msg,
+        List<LsOpinionItem> t3401OutBlock1
+) {
+    public record LsOpinionItem(
+            String date,        // 의견일자
+            String tradname,    // 회원사명
+            String bopn,        // 투자의견 변경후
+            String nopn,        // 투자의견 변경전
+            int noga,           // 목표가 변경후
+            int boga            // 목표가 변경전
+    ) {}
+
+
+}

--- a/src/main/java/com/sollite/market/dto/LsOpinionRes.java
+++ b/src/main/java/com/sollite/market/dto/LsOpinionRes.java
@@ -15,6 +15,4 @@ public record LsOpinionRes (
             int noga,           // 목표가 변경후
             int boga            // 목표가 변경전
     ) {}
-
-
 }

--- a/src/main/java/com/sollite/market/dto/OpinionResponse.java
+++ b/src/main/java/com/sollite/market/dto/OpinionResponse.java
@@ -1,0 +1,17 @@
+package com.sollite.market.dto;
+
+import java.util.List;
+
+public record OpinionResponse(
+        String stockCode,
+        List<OpinionItem> opinions
+) {
+    public record OpinionItem(
+            String date,
+            String brokerName,
+            String opinion,
+            String previousOpinion,
+            int targetPrice,
+            int previousTargetPrice
+    ) {}
+}

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -290,4 +290,193 @@ class LsMarketServiceImpl implements MarketService {
             throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
         }
     }
+
+    @Override
+    public FinanceResponse getFinance(String stockCode) {
+        return getFinance(stockCode, false);
+    }
+
+    private FinanceResponse getFinance(String stockCode, boolean isRetry) {
+        String token = tokenService.getAccessToken();
+        try {
+            record LsReqBody(String gicode) {}
+            record LsReq(LsReqBody t3320InBlock) {}
+
+            String raw = lsWebClient.post()
+                    .uri("/stock/investinfo")
+                    .header("authorization", "Bearer " + token)
+                    .header("content-type", "application/json; charset=utf-8")
+                    .header("tr_cd", "t3320")
+                    .header("tr_cont", "N")
+                    .header("mac_address", DUMMY_MAC)
+                    .bodyValue(new LsReq(new LsReqBody(stockCode)))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.debug("LS t3320 finance raw: {}", raw);
+            LsFinanceRes lsRes = objectMapper.readValue(raw, LsFinanceRes.class);
+
+            if (lsRes == null || !"00000".equals(lsRes.rsp_cd())) {
+                log.warn("LS API 재무 요약 조회 실패: stockCode={}, msg={}", stockCode, lsRes!= null ? lsRes.rsp_msg() : "NULL");
+                throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+            }
+
+            LsFinanceRes.LsFinanceBlock b = lsRes.t3320OutBlock();
+            LsFinanceRes.LsFinanceBlock1 b1 = lsRes.t3320OutBlock1();
+
+            if (b == null || b1 == null) {
+                throw new BusinessException(MarketErrorCode.MARKET_DATA_NOT_FOUND);
+            }
+
+            return new FinanceResponse(
+                    stockCode,
+                    b.sigavalue(),
+                    b1.per(),
+                    b1.pbr(),
+                    b1.eps(),
+                    b1.bps(),
+                    b.capital(),
+                    b1.roe(),
+                    b.foreignratio(),
+                    b1.gsym()
+            );
+        } catch (BusinessException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            if (!isRetry && e.getStatusCode().value() == 401) {
+                log.warn("토큰 만료 감지 (401), 재발급 후 재시도: stockCode={}", stockCode);
+                tokenService.invalidateToken();
+                return getFinance(stockCode, true);
+            }
+            log.error("LS증권 API 호출 실패. HTTP 상태: {}, 응답: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        } catch (Exception e) {
+            log.error("재무 요약 조회 중 예외 발생: stockCode={}", stockCode, e);
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        }
+    }
+
+    @Override
+    public OpinionResponse getOpinion(String stockCode) {
+        return getOpinion(stockCode, false);
+    }
+
+    private OpinionResponse getOpinion(String stockCode, boolean isRetry) {
+        String token = tokenService.getAccessToken();
+        try {
+            record LsReqBody(String shcode, String gubun1, String tradno, String cts_date) {}
+            record LsReq(LsReqBody t3401InBlock) {}
+
+            String raw = lsWebClient.post()
+                    .uri("/stock/investinfo")
+                    .header("authorization", "Bearer " + token)
+                    .header("content-type", "application/json; charset=utf-8")
+                    .header("tr_cd", "t3401")
+                    .header("tr_cont", "N")
+                    .header("mac_address", DUMMY_MAC)
+                    .bodyValue(new LsReq(new LsReqBody(stockCode, "", "", "")))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.debug("LS t3401 opinion raw: {}", raw);
+            LsOpinionRes lsRes = objectMapper.readValue(raw, LsOpinionRes.class);
+
+            if (lsRes == null || !"00000".equals(lsRes.rsp_cd())) {
+                log.warn("LS API 투자의견 조회 실패: stockCode={}, msg={}", stockCode, lsRes != null ? lsRes.rsp_msg() : "NULL");
+                throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+            }
+
+            List<LsOpinionRes.LsOpinionItem> rawList = lsRes.t3401OutBlock1() != null ? lsRes.t3401OutBlock1() : List.of();
+            List<OpinionResponse.OpinionItem> opinions = rawList.stream()
+                    .map(item -> new OpinionResponse.OpinionItem(
+                            item.date(),
+                            item.tradname(),
+                            item.bopn(),
+                            item.nopn(),
+                            item.noga(),
+                            item.boga()
+                    ))
+                    .toList();
+
+            return new OpinionResponse(stockCode, opinions);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            if (!isRetry && e.getStatusCode().value() == 401) {
+                log.warn("토큰 만료 감지 (401), 재발급 후 재시도: stockCode={}", stockCode);
+                tokenService.invalidateToken();
+                return getOpinion(stockCode, true);
+            }
+            log.error("LS증권 API 호출 실패. HTTP 상태: {}, 응답: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        } catch (Exception e) {
+            log.error("투자의견 조회 중 예외 발생: stockCode: {}", stockCode, e);
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        }
+    }
+
+    @Override
+    public InvestorResponse getInvestor(String stockCode) {
+        return getInvestor(stockCode, false);
+    }
+
+    private InvestorResponse getInvestor(String stockCode, boolean isRetry) {
+        String token = tokenService.getAccessToken();
+        try {
+            record LsReqBody(String shcode, String gubun, String fromdt, String todt, String exchgubun) {}
+            record LsReq(LsReqBody t1717InBlock) {}
+
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMdd");
+            String today = LocalDate.now().format(fmt);
+
+            String raw = lsWebClient.post()
+                    .uri("/stock/frgr-itt")
+                    .header("authorization", "Bearer " + token)
+                    .header("content-type", "application/json; charset=utf-8")
+                    .header("tr_cd", "t1717")
+                    .header("tr_cont", "N")
+                    .header("mac_address", DUMMY_MAC)
+                    .bodyValue(new LsReq(new LsReqBody(stockCode, "0", today, today, "K")))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.debug("LS t1717 investor raw: {}", raw);
+            LsInvestorRes lsRes = objectMapper.readValue(raw, LsInvestorRes.class);
+
+            if (lsRes == null || !"00000".equals(lsRes.rsp_cd())) {
+                log.warn("LS API 투자자 동향 조회 실패: stockCode={}, msg={}", stockCode, lsRes != null ? lsRes.rsp_msg() : "NULL");
+                throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+            }
+
+            List<LsInvestorRes.LsInvestorItem> rawList = lsRes.t1717OutBlock() != null ? lsRes.t1717OutBlock() : List.of();
+            LsInvestorRes.LsInvestorItem item = rawList.stream()
+                    .findFirst()
+                    .orElseThrow(() -> new BusinessException(MarketErrorCode.MARKET_DATA_NOT_FOUND));
+
+            return new InvestorResponse(
+                    stockCode,
+                    item.date(),
+                    item.close(),
+                    item.tjj0016_vol(),
+                    item.tjj0018_vol(),
+                    item.tjj0008_vol()
+            );
+        } catch (BusinessException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            if (!isRetry && e.getStatusCode().value() == 401) {
+                log.warn("토큰 만료 감지 (401), 재발급 후 재시도: stockCode={}", stockCode);
+                tokenService.invalidateToken();
+                return getInvestor(stockCode, true);
+            }
+            log.error("LS증권 API 호출 실패. HTTP 상태: {}, 응답: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        } catch (Exception e) {
+            log.error("투자자 동향 조회 중 예외 발생: stockCode={}", stockCode, e);
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/sollite/market/service/MarketService.java
+++ b/src/main/java/com/sollite/market/service/MarketService.java
@@ -5,6 +5,9 @@ import com.sollite.market.dto.DailyPriceResponse;
 import com.sollite.market.dto.ChartPeriod;
 import com.sollite.market.dto.ChartResponse;
 import com.sollite.market.dto.MinuteChartResponse;
+import com.sollite.market.dto.FinanceResponse;
+import com.sollite.market.dto.OpinionResponse;
+import com.sollite.market.dto.InvestorResponse;
 
 import java.time.LocalDate;
 
@@ -13,4 +16,7 @@ public interface MarketService {
     DailyPriceResponse getDailyPrice(String stockCode, LocalDate date);
     ChartResponse getChart(String stockCode, ChartPeriod period, LocalDate startDate, LocalDate endDate);
     MinuteChartResponse getMinuteChart(String stockCode, int ncnt);
+    FinanceResponse getFinance(String stockCode);
+    OpinionResponse getOpinion(String stockCode);
+    InvestorResponse getInvestor(String stockCode);
 }


### PR DESCRIPTION
## 작업 내용
- t3320 TR 연동으로 종목별 재무정보 조회 구현 (PER, PBR, EPS, BPS, ROE, 시가총액, 자본금, 외국인비율)
- t3401 TR 연동으로 증권사별 투자의견 및 목표주가 조회 구현
- t1717 TR 연동으로 당일 외인/기관/개인 순매수 현황 조회 구현

## Changes
**신규 엔드포인트**
- `GET /api/market/stocks/{stockCode}/finance` — PER, PBR, EPS, BPS, ROE, 시가총액, 자본금, 외국인비율, 결산년월
- `GET /api/market/stocks/{stockCode}/opinion` — 증권사별 투자의견 변경 이력 및 목표주가
- `GET /api/market/stocks/{stockCode}/investor` — 당일 외인계/기관/개인 순매수 수량

**신규 파일**
- `dto/LsFinanceRes.java`, `dto/FinanceResponse.java`
- `dto/LsOpinionRes.java`, `dto/OpinionResponse.java`
- `dto/LsInvestorRes.java`, `dto/InvestorResponse.java`

## Test plan
- [x] `GET /api/market/stocks/005930/finance` 응답 정상 확인
- [x] `GET /api/market/stocks/005930/opinion` 증권사별 투자의견 목록 확인
- [x] `GET /api/market/stocks/005930/investor` 당일 외인/기관/개인 순매수 확인
- [ ] 토큰 만료 시 자동 재발급 후 재시도 동작 확인

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
