### PR TITLE
feat(market): 종목 호가/예상체결 조회 API 구현

### DIFF
--- a/src/main/java/com/sollite/market/controller/MarketController.java
+++ b/src/main/java/com/sollite/market/controller/MarketController.java
@@ -58,4 +58,9 @@ public class MarketController {
     public ResponseEntity<InvestorResponse> getInvestor(@PathVariable String stockCode) {
         return ResponseEntity.ok(marketService.getInvestor(stockCode));
     }
+
+    @GetMapping("/stocks/{stockCode}/orderbook")
+    public ResponseEntity<OrderbookResponse> getOrderbook(@PathVariable String stockCode) {
+        return ResponseEntity.ok(marketService.getOrderbook(stockCode));
+    }
 }

--- a/src/main/java/com/sollite/market/dto/LsOrderbookRes.java
+++ b/src/main/java/com/sollite/market/dto/LsOrderbookRes.java
@@ -1,0 +1,30 @@
+package com.sollite.market.dto;
+
+public record LsOrderbookRes(
+        String rsp_cd,
+        String rsp_msg,
+        LsOrderbookBlock t1101OutBlock
+) {
+    public record LsOrderbookBlock(
+            String hotime,
+            // 매도호가 1~10
+            int offerho1, int offerho2, int offerho3, int offerho4, int offerho5,
+            int offerho6, int offerho7, int offerho8, int offerho9, int offerho10,
+            // 매도호가수량 1~10
+            long offerrem1, long offerrem2, long offerrem3, long offerrem4, long offerrem5,
+            long offerrem6, long offerrem7, long offerrem8, long offerrem9, long offerrem10,
+            // 매수호가 1~10
+            int bidho1, int bidho2, int bidho3, int bidho4, int bidho5,
+            int bidho6, int bidho7, int bidho8, int bidho9, int bidho10,
+            // 매수호가수량 1~10
+            long bidrem1, long bidrem2, long bidrem3, long bidrem4, long bidrem5,
+            long bidrem6, long bidrem7, long bidrem8, long bidrem9, long bidrem10,
+            // 합계
+            long offer,     // 매도호가수량합
+            long bid,       // 매수호가수량합
+            // 예상체결
+            int yeprice,
+            long yevolume,
+            String yediff
+    ) {}
+}

--- a/src/main/java/com/sollite/market/dto/LsOrderbookRes.java
+++ b/src/main/java/com/sollite/market/dto/LsOrderbookRes.java
@@ -1,5 +1,7 @@
 package com.sollite.market.dto;
 
+import java.util.List;
+
 public record LsOrderbookRes(
         String rsp_cd,
         String rsp_msg,
@@ -7,24 +9,48 @@ public record LsOrderbookRes(
 ) {
     public record LsOrderbookBlock(
             String hotime,
-            // 매도호가 1~10
             int offerho1, int offerho2, int offerho3, int offerho4, int offerho5,
             int offerho6, int offerho7, int offerho8, int offerho9, int offerho10,
-            // 매도호가수량 1~10
             long offerrem1, long offerrem2, long offerrem3, long offerrem4, long offerrem5,
             long offerrem6, long offerrem7, long offerrem8, long offerrem9, long offerrem10,
-            // 매수호가 1~10
             int bidho1, int bidho2, int bidho3, int bidho4, int bidho5,
             int bidho6, int bidho7, int bidho8, int bidho9, int bidho10,
-            // 매수호가수량 1~10
             long bidrem1, long bidrem2, long bidrem3, long bidrem4, long bidrem5,
             long bidrem6, long bidrem7, long bidrem8, long bidrem9, long bidrem10,
-            // 합계
-            long offer,     // 매도호가수량합
-            long bid,       // 매수호가수량합
-            // 예상체결
+            long offer,
+            long bid,
             int yeprice,
             long yevolume,
             String yediff
-    ) {}
+    ) {
+        public List<OrderbookResponse.OrderEntry> toAsks() {
+            return List.of(
+                    new OrderbookResponse.OrderEntry(offerho1(), offerrem1()),
+                    new OrderbookResponse.OrderEntry(offerho2(), offerrem2()),
+                    new OrderbookResponse.OrderEntry(offerho3(), offerrem3()),
+                    new OrderbookResponse.OrderEntry(offerho4(), offerrem4()),
+                    new OrderbookResponse.OrderEntry(offerho5(), offerrem5()),
+                    new OrderbookResponse.OrderEntry(offerho6(), offerrem6()),
+                    new OrderbookResponse.OrderEntry(offerho7(), offerrem7()),
+                    new OrderbookResponse.OrderEntry(offerho8(), offerrem8()),
+                    new OrderbookResponse.OrderEntry(offerho9(), offerrem9()),
+                    new OrderbookResponse.OrderEntry(offerho10(), offerrem10())
+            );
+        }
+
+        public List<OrderbookResponse.OrderEntry> toBids() {
+            return List.of(
+                    new OrderbookResponse.OrderEntry(bidho1(), bidrem1()),
+                    new OrderbookResponse.OrderEntry(bidho2(), bidrem2()),
+                    new OrderbookResponse.OrderEntry(bidho3(), bidrem3()),
+                    new OrderbookResponse.OrderEntry(bidho4(), bidrem4()),
+                    new OrderbookResponse.OrderEntry(bidho5(), bidrem5()),
+                    new OrderbookResponse.OrderEntry(bidho6(), bidrem6()),
+                    new OrderbookResponse.OrderEntry(bidho7(), bidrem7()),
+                    new OrderbookResponse.OrderEntry(bidho8(), bidrem8()),
+                    new OrderbookResponse.OrderEntry(bidho9(), bidrem9()),
+                    new OrderbookResponse.OrderEntry(bidho10(), bidrem10())
+            );
+        }
+    }
 }

--- a/src/main/java/com/sollite/market/dto/OrderbookResponse.java
+++ b/src/main/java/com/sollite/market/dto/OrderbookResponse.java
@@ -1,0 +1,19 @@
+package com.sollite.market.dto;
+
+import java.util.List;
+
+public record OrderbookResponse(
+        String stockCode,
+        String hotime,          // 수신시간
+        int yeprice,            // 예상체결가격
+        long yevolume,          // 예상체결수량
+        String yediff,          // 예상체결등락율
+        long offerTotal,        // 매도호가수량합
+        long bidTotal,          // 매수호가수량합
+        List<OrderEntry> asks,  // 매도호가 목록 (1~10)
+        List<OrderEntry> bids   // 매수호가 목록 (1~10)
+) {
+    public record OrderEntry(
+            int price, long volume
+    ) {}
+}

--- a/src/main/java/com/sollite/market/dto/OrderbookResponse.java
+++ b/src/main/java/com/sollite/market/dto/OrderbookResponse.java
@@ -4,16 +4,17 @@ import java.util.List;
 
 public record OrderbookResponse(
         String stockCode,
-        String hotime,          // 수신시간
-        int yeprice,            // 예상체결가격
-        long yevolume,          // 예상체결수량
-        String yediff,          // 예상체결등락율
-        long offerTotal,        // 매도호가수량합
-        long bidTotal,          // 매수호가수량합
-        List<OrderEntry> asks,  // 매도호가 목록 (1~10)
-        List<OrderEntry> bids   // 매수호가 목록 (1~10)
+        String hotime,              // 수신시간
+        int expectedPrice,          // 예상체결가격
+        long expectedVolume,        // 예상체결수량
+        double expectedChangeRate,  // 예상체결등락율
+        long offerTotal,            // 매도호가수량합
+        long bidTotal,              // 매수호가수량합
+        List<OrderEntry> asks,      // 매도호가 목록 (1~10)
+        List<OrderEntry> bids       // 매수호가 목록 (1~10)
 ) {
     public record OrderEntry(
-            int price, long volume
+            int price,
+            long volume
     ) {}
 }

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -549,11 +549,11 @@ class LsMarketServiceImpl implements MarketService {
                     b.hotime(),
                     b.yeprice(),
                     b.yevolume(),
-                    b.yediff(),
+                    Double.parseDouble(b.yediff().trim()),
                     b.offer(),
                     b.bid(),
-                    asks,
-                    bids
+                    b.toAsks(),
+                    b.toBids()
             );
 
         } catch (BusinessException e) {

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -7,6 +7,7 @@ import com.sollite.market.exception.MarketErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.query.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -476,6 +477,97 @@ class LsMarketServiceImpl implements MarketService {
             throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
         } catch (Exception e) {
             log.error("투자자 동향 조회 중 예외 발생: stockCode={}", stockCode, e);
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        }
+    }
+
+    @Override
+    public OrderbookResponse getOrderbook(String stockCode) {
+        return getOrderbook(stockCode, false);
+    }
+
+    private OrderbookResponse getOrderbook(String stockCode, boolean isRetry) {
+        String token = tokenService.getAccessToken();
+        try {
+            record LsReqBody(String shcode) {}
+            record LsReq(LsReqBody t1101InBlock) {}
+
+            String raw = lsWebClient.post()
+                    .uri("/stock/market-data")
+                    .header("authorization", "Bearer " + token)
+                    .header("content-type", "application/json; charset=utf-8")
+                    .header("tr_cd", "t1101")
+                    .header("tr_cont", "N")
+                    .header("mac_address", DUMMY_MAC)
+                    .bodyValue(new LsReq(new LsReqBody(stockCode)))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.debug("LS t1101 orderbook raw: {}", raw);
+            LsOrderbookRes lsRes = objectMapper.readValue(raw, LsOrderbookRes.class);
+
+            if (lsRes == null || !"00000".equals(lsRes.rsp_cd())) {
+                log.warn("LS API 호가 조회 실패: stockCode={}, msg={}", stockCode,
+                        lsRes != null ? lsRes.rsp_msg() : "NULL");
+                throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+            }
+
+            LsOrderbookRes.LsOrderbookBlock b = lsRes.t1101OutBlock();
+            if (b == null) {
+                throw new BusinessException(MarketErrorCode.MARKET_DATA_NOT_FOUND);
+            }
+
+            List<OrderbookResponse.OrderEntry> asks = List.of(
+                    new OrderbookResponse.OrderEntry(b.offerho1(),  b.offerrem1()),
+                    new OrderbookResponse.OrderEntry(b.offerho2(),  b.offerrem2()),
+                    new OrderbookResponse.OrderEntry(b.offerho3(),  b.offerrem3()),
+                    new OrderbookResponse.OrderEntry(b.offerho4(),  b.offerrem4()),
+                    new OrderbookResponse.OrderEntry(b.offerho5(),  b.offerrem5()),
+                    new OrderbookResponse.OrderEntry(b.offerho6(),  b.offerrem6()),
+                    new OrderbookResponse.OrderEntry(b.offerho7(),  b.offerrem7()),
+                    new OrderbookResponse.OrderEntry(b.offerho8(),  b.offerrem8()),
+                    new OrderbookResponse.OrderEntry(b.offerho9(),  b.offerrem9()),
+                    new OrderbookResponse.OrderEntry(b.offerho10(), b.offerrem10())
+            );
+
+            List<OrderbookResponse.OrderEntry> bids = List.of(
+                    new OrderbookResponse.OrderEntry(b.bidho1(),  b.bidrem1()),
+                    new OrderbookResponse.OrderEntry(b.bidho2(),  b.bidrem2()),
+                    new OrderbookResponse.OrderEntry(b.bidho3(),  b.bidrem3()),
+                    new OrderbookResponse.OrderEntry(b.bidho4(),  b.bidrem4()),
+                    new OrderbookResponse.OrderEntry(b.bidho5(),  b.bidrem5()),
+                    new OrderbookResponse.OrderEntry(b.bidho6(),  b.bidrem6()),
+                    new OrderbookResponse.OrderEntry(b.bidho7(),  b.bidrem7()),
+                    new OrderbookResponse.OrderEntry(b.bidho8(),  b.bidrem8()),
+                    new OrderbookResponse.OrderEntry(b.bidho9(),  b.bidrem9()),
+                    new OrderbookResponse.OrderEntry(b.bidho10(), b.bidrem10())
+            );
+
+            return new OrderbookResponse(
+                    stockCode,
+                    b.hotime(),
+                    b.yeprice(),
+                    b.yevolume(),
+                    b.yediff(),
+                    b.offer(),
+                    b.bid(),
+                    asks,
+                    bids
+            );
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            if (!isRetry && e.getStatusCode().value() == 401) {
+                log.warn("토큰 만료 감지 (401), 재발급 후 재시도: stockCode={}", stockCode);
+                tokenService.invalidateToken();
+                return getOrderbook(stockCode, true);
+            }
+            log.error("LS증권 API 호출 실패. HTTP 상태: {}, 응답: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        } catch (Exception e) {
+            log.error("호가 조회 중 예외 발생: stockCode={}", stockCode, e);
             throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
         }
     }

--- a/src/main/java/com/sollite/market/service/MarketService.java
+++ b/src/main/java/com/sollite/market/service/MarketService.java
@@ -8,6 +8,8 @@ import com.sollite.market.dto.MinuteChartResponse;
 import com.sollite.market.dto.FinanceResponse;
 import com.sollite.market.dto.OpinionResponse;
 import com.sollite.market.dto.InvestorResponse;
+import com.sollite.market.dto.OrderbookResponse;
+import org.hibernate.query.Order;
 
 import java.time.LocalDate;
 
@@ -19,4 +21,5 @@ public interface MarketService {
     FinanceResponse getFinance(String stockCode);
     OpinionResponse getOpinion(String stockCode);
     InvestorResponse getInvestor(String stockCode);
+    OrderbookResponse getOrderbook(String stockCode);
 }


### PR DESCRIPTION
## 연관된 이슈

> 없음

## 작업 내용

LS증권 `t1101` TR을 연동하여 종목별 호가/예상체결 조회 API를 구현했습니다.

- `GET /api/market/stocks/{stockCode}/orderbook`
- 매수/매도 10호가 및 잔량 조회
- 예상체결가격, 예상체결수량, 예상체결등락율 포함
- LS API의 flat 구조(`offerho1~10`, `bidho1~10`)를 `List<OrderEntry>`로 변환하여 응답

**신규 파일**
- `dto/LsOrderbookRes.java` — t1101 응답 역직렬화
- `dto/OrderbookResponse.java` — 클라이언트 응답 DTO

### 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [ ] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> LS API 응답이 `offerho1~10` 형태의 flat 구조라 필드를 하나씩 선언했는데, 더 나은 방식이 있다면 의견 부탁드립니다.
