### PR TITLE
refactor(global): LsTokenService 공통 모듈로 이동 및 웹소켓 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // ── Websocket ──
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 test {

--- a/src/main/java/com/sollite/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/sollite/global/exception/GlobalErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum GlobalErrorCode implements ErrorCode {
 
     INVALID_INPUT(400, "입력값이 올바르지 않습니다"),
-    INTERNAL_ERROR(500, "서버 내부 오류가 발생했습니다");
+    INTERNAL_ERROR(500, "서버 내부 오류가 발생했습니다"),
+    LS_TOKEN_FETCH_FAILED(502, "LS증권 API 토큰 발급에 실패했습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/global/service/LsTokenService.java
+++ b/src/main/java/com/sollite/global/service/LsTokenService.java
@@ -1,7 +1,7 @@
-package com.sollite.market.service;
+package com.sollite.global.service;
 
 import com.sollite.global.exception.BusinessException;
-import com.sollite.market.exception.MarketErrorCode;
+import com.sollite.global.exception.GlobalErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,12 +16,13 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class LsTokenService {
+
     private final WebClient lsWebClient;
 
     private String cachedToken;
     private Instant tokenExpiresAt;
 
-    @Value("${ls.api.appkey}") private String appKey;
+    @Value("${ls.api.appkey}")    private String appKey;
     @Value("${ls.api.appsecret}") private String appSecret;
 
     public synchronized String getAccessToken() {
@@ -55,6 +56,6 @@ public class LsTokenService {
             log.info("새 토큰 발급 완료, 만료까지 {}초", expiresIn);
             return;
         }
-        throw new BusinessException(MarketErrorCode.LS_TOKEN_FETCH_FAILED);
+        throw new BusinessException(GlobalErrorCode.LS_TOKEN_FETCH_FAILED);
     }
 }

--- a/src/main/java/com/sollite/global/service/LsTokenService.java
+++ b/src/main/java/com/sollite/global/service/LsTokenService.java
@@ -22,7 +22,7 @@ public class LsTokenService {
     private String cachedToken;
     private Instant tokenExpiresAt;
 
-    @Value("${ls.api.appkey}")    private String appKey;
+    @Value("${ls.api.appkey}") private String appKey;
     @Value("${ls.api.appsecret}") private String appSecret;
 
     public synchronized String getAccessToken() {

--- a/src/main/java/com/sollite/market/exception/MarketErrorCode.java
+++ b/src/main/java/com/sollite/market/exception/MarketErrorCode.java
@@ -10,7 +10,6 @@ public enum MarketErrorCode implements ErrorCode {
 
     INVALID_STOCK_CODE(400, "종목코드 형식이 올바르지 않습니다"),
     STOCK_NOT_FOUND(404, "등록되지 않은 종목입니다"),
-    LS_TOKEN_FETCH_FAILED(502, "LS증권 API 토큰 발급에 실패했습니다"),
     MARKET_API_ERROR(502, "시세 조회에 실패했습니다. 잠시 후 다시 시도해주세요"),
     MARKET_DATA_NOT_FOUND(404, "해당 날짜의 시세 데이터가 없습니다");
 

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -2,6 +2,7 @@ package com.sollite.market.service;
 
 import com.sollite.global.exception.BusinessException;
 import com.sollite.market.dto.*;
+import com.sollite.global.service.LsTokenService;
 import com.sollite.market.exception.MarketErrorCode;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,14 +92,11 @@ logging:
     org.hibernate.SQL: DEBUG
 
 
-# ── LS Securities API ──
+# ── LS Securities API  & Websocket ──
 ls:
   api:
     url: "https://openapi.ls-sec.co.kr:8080"
     appkey: ${LS_APPKEY}
     appsecret: ${LS_APPSECRET}
-
-# ── LS Websocket ──
-ls:
   ws:
     url: wss://openapi.ls-sec.co.kr:9443/websocket

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,3 +98,8 @@ ls:
     url: "https://openapi.ls-sec.co.kr:8080"
     appkey: ${LS_APPKEY}
     appsecret: ${LS_APPSECRET}
+
+# ── LS Websocket ──
+ls:
+  ws:
+    url: wss://openapi.ls-sec.co.kr:9443/websocket


### PR DESCRIPTION
## 연관된 이슈

> 없음

## 작업 내용

LS증권 WebSocket(H1_) 연동으로 종목별 실시간 호가 수신 기능을 구현했습니다.

**구조 변경**
- `LsTokenService`를 `market` → `global/service`로 이동 (websocket 모듈에서도 공유 가능하도록)
- `LS_TOKEN_FETCH_FAILED` 에러코드를 `MarketErrorCode` → `GlobalErrorCode`로 이동
- `spring-boot-starter-websocket` 의존성 추가
- `ls.ws.url` 설정 추가

**신규 구현**
- `GET /ws/asking/{stockCode}` — 종목별 실시간 매수/매도 10호가 및 잔량 WebSocket 수신
- 프론트 연결 시 LS WebSocket 구독 자동 시작, 연결 종료 시 구독 해제
- `ConcurrentWebSocketSessionDecorator`로 멀티스레드 환경 동시 전송 안전 처리

**신규 파일**
- `websocket/dto/LsAskingRes.java` — H1_ 응답 파싱 및 변환
- `websocket/dto/AskingResponse.java` — 프론트 WebSocket 응답 DTO
- `websocket/config/WebSocketConfig.java` — WebSocket 엔드포인트 등록
- `websocket/controller/AskingWebSocketHandler.java` — LS 연결 관리 및 relay 처리

### 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [ ] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> `AskingWebSocketHandler`에서 프론트 연결 종료 시 LS 구독을 `dispose()`로 해제하는 방식이 적절한지 검토 부탁드립니다.
