### PR TITLE
feat(websocket): 실시간 호가 WebSocket 구현

### DIFF
--- a/src/main/java/com/sollite/global/config/SecurityConfig.java
+++ b/src/main/java/com/sollite/global/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                                 "/api/auth/email/verify/**",
                                 "/api/auth/password/reset/**",
                                 "/api/market/**",
+                                "/ws/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/swagger-resources/**",

--- a/src/main/java/com/sollite/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/sollite/websocket/config/WebSocketConfig.java
@@ -1,0 +1,21 @@
+package com.sollite.websocket.config;
+
+import com.sollite.websocket.controller.AskingWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final AskingWebSocketHandler askingWebSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(askingWebSocketHandler, "/ws/asking/*")
+                .setAllowedOriginPatterns("*");
+    }
+}

--- a/src/main/java/com/sollite/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/sollite/websocket/config/WebSocketConfig.java
@@ -2,6 +2,7 @@ package com.sollite.websocket.config;
 
 import com.sollite.websocket.controller.AskingWebSocketHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
@@ -13,9 +14,12 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 public class WebSocketConfig implements WebSocketConfigurer {
     private final AskingWebSocketHandler askingWebSocketHandler;
 
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(askingWebSocketHandler, "/ws/asking/*")
-                .setAllowedOriginPatterns("*");
+                .setAllowedOriginPatterns(frontendUrl);
     }
 }

--- a/src/main/java/com/sollite/websocket/controller/AskingWebSocketHandler.java
+++ b/src/main/java/com/sollite/websocket/controller/AskingWebSocketHandler.java
@@ -1,0 +1,139 @@
+package com.sollite.websocket.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sollite.global.service.LsTokenService;
+import com.sollite.websocket.dto.AskingResponse;
+import com.sollite.websocket.dto.LsAskingRes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AskingWebSocketHandler extends TextWebSocketHandler {
+    private final LsTokenService lsTokenService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${ls.ws.url}")
+    private String lsWsUrl;
+
+    private static final String TR_CD = "H1_";
+
+    private final Map<String, ConcurrentWebSocketSessionDecorator> frontendSessions = new ConcurrentHashMap<>();
+    private final Map<String, Disposable> lsSubscriptions = new ConcurrentHashMap<>();
+
+    // 프론트 /ws/asking/{stockCode} 연결 시
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        String sessionId = session.getId();
+        String stockCode = extractStockCode(session);
+
+        ConcurrentWebSocketSessionDecorator safeSession = new ConcurrentWebSocketSessionDecorator(session, 5000, 65536);
+        frontendSessions.put(sessionId, safeSession);
+
+        log.info("프론트 웹소켓 연결: sessionId={}, stockCode={}", sessionId, stockCode);
+        connectToLs(sessionId, stockCode, safeSession);
+    }
+
+    // 프론트에서 메시지 보낼 시
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) {}
+
+    // 프론트 연결 종료 시
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        String sessionId = session.getId();
+
+        // LS 구독 해제
+        Disposable sub = lsSubscriptions.remove(sessionId);
+        if (sub != null && !sub.isDisposed()) {
+            sub.dispose();
+        }
+        frontendSessions.remove(sessionId);
+        log.info("프론트 웹소켓 종료: sessionId={}, status={}", sessionId, status);
+    }
+
+    // 전송 오류 발생 시
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) {
+        log.error("웹소켓 전송 오류: sessionId={}, error={}", session.getId(), exception.getMessage());
+    }
+
+    // LS WebSocket 연결 + 실시간 데이터 수신
+    private void connectToLs(String sessionId, String stockCode, ConcurrentWebSocketSessionDecorator frontendSession) {
+        String token = lsTokenService.getAccessToken();
+        ReactorNettyWebSocketClient lsClient = new ReactorNettyWebSocketClient();
+
+        Disposable subscription = lsClient.execute(URI.create(lsWsUrl), lsSession -> {
+            String subMsg = buildMessage(token, "3", stockCode);
+            Mono<Void> send = lsSession.send(
+                    Mono.just(lsSession.textMessage(subMsg))
+            );
+
+            Mono<Void> receive = lsSession.receive()
+                    .filter(msg -> msg.getType() == WebSocketMessage.Type.TEXT)
+                    .doOnNext(msg -> relay(frontendSession, msg.getPayloadAsText(), stockCode))
+                    .then();
+
+            return send.then(receive);
+        }).subscribe(
+                null,
+                error -> log.error("LS 웹소켓 오류: sessionId={}, error={}", sessionId, error.getMessage()),
+                () -> log.info("LS 웹소켓 연결 종료: sessionId={}", sessionId)
+        );
+        lsSubscriptions.put(sessionId, subscription);
+    }
+
+    private void relay(ConcurrentWebSocketSessionDecorator frontendSession, String lsPayload, String stockCode) {
+        try {
+            LsAskingRes lsRes = objectMapper.readValue(lsPayload, LsAskingRes.class);
+            LsAskingRes.LsAskingBody body = lsRes.body();
+            if (body == null) return;
+
+            AskingResponse response = new AskingResponse(
+                    stockCode,
+                    body.hotime(),
+                    body.parsedTotOfferRem(),
+                    body.parsedTotBidRem(),
+                    body.toAsks(),
+                    body.toBids()
+            );
+
+            String json = objectMapper.writeValueAsString(response);
+
+            if (frontendSession.isOpen()) {
+                frontendSession.sendMessage(new TextMessage(json));
+            }
+        } catch (Exception e) {
+            log.warn("LS 메시지 처리 실패: {}", e.getMessage());
+        }
+    }
+
+    // LS WebSocket 구독/해제 메시지
+    private String buildMessage(String token, String trType, String stockCode) {
+        return String.format(
+                "{\"header\":{\"token\":\"%s\",\"tr_type\":\"%s\"},\"body\":{\"tr_cd\":\"%s\",\"tr_key\":\"%s\"}}",
+                token, trType, TR_CD, stockCode
+        );
+    }
+
+    private String extractStockCode(WebSocketSession session) {
+        String path = session.getUri().getPath();
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+}

--- a/src/main/java/com/sollite/websocket/controller/AskingWebSocketHandler.java
+++ b/src/main/java/com/sollite/websocket/controller/AskingWebSocketHandler.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Component
@@ -33,26 +34,32 @@ public class AskingWebSocketHandler extends TextWebSocketHandler {
     private String lsWsUrl;
 
     private static final String TR_CD = "H1_";
+    private static final int MAX_SESSIONS = 100;
 
+    private final ReactorNettyWebSocketClient lsClient = new ReactorNettyWebSocketClient();
     private final Map<String, ConcurrentWebSocketSessionDecorator> frontendSessions = new ConcurrentHashMap<>();
     private final Map<String, Disposable> lsSubscriptions = new ConcurrentHashMap<>();
+    private final AtomicInteger sessionCount = new AtomicInteger(0);
 
     // 프론트 /ws/asking/{stockCode} 연결 시
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) {
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        if (sessionCount.get() >= MAX_SESSIONS) {
+            log.warn("최대 세션 수 초과: sessionId={}", session.getId());
+            session.close(CloseStatus.SERVICE_OVERLOAD);
+            return;
+        }
+
         String sessionId = session.getId();
         String stockCode = extractStockCode(session);
 
         ConcurrentWebSocketSessionDecorator safeSession = new ConcurrentWebSocketSessionDecorator(session, 5000, 65536);
         frontendSessions.put(sessionId, safeSession);
+        sessionCount.incrementAndGet();
 
         log.info("프론트 웹소켓 연결: sessionId={}, stockCode={}", sessionId, stockCode);
         connectToLs(sessionId, stockCode, safeSession);
     }
-
-    // 프론트에서 메시지 보낼 시
-    @Override
-    protected void handleTextMessage(WebSocketSession session, TextMessage message) {}
 
     // 프론트 연결 종료 시
     @Override
@@ -65,6 +72,7 @@ public class AskingWebSocketHandler extends TextWebSocketHandler {
             sub.dispose();
         }
         frontendSessions.remove(sessionId);
+        sessionCount.decrementAndGet();
         log.info("프론트 웹소켓 종료: sessionId={}, status={}", sessionId, status);
     }
 
@@ -77,7 +85,6 @@ public class AskingWebSocketHandler extends TextWebSocketHandler {
     // LS WebSocket 연결 + 실시간 데이터 수신
     private void connectToLs(String sessionId, String stockCode, ConcurrentWebSocketSessionDecorator frontendSession) {
         String token = lsTokenService.getAccessToken();
-        ReactorNettyWebSocketClient lsClient = new ReactorNettyWebSocketClient();
 
         Disposable subscription = lsClient.execute(URI.create(lsWsUrl), lsSession -> {
             String subMsg = buildMessage(token, "3", stockCode);

--- a/src/main/java/com/sollite/websocket/dto/AskingResponse.java
+++ b/src/main/java/com/sollite/websocket/dto/AskingResponse.java
@@ -1,0 +1,17 @@
+package com.sollite.websocket.dto;
+
+import java.util.List;
+
+public record AskingResponse(
+        String stockCode,           // 종목코드
+        String hotime,              // 호가시간 (예: "093012")
+        long totalOfferVolume,      // 총 매도잔량
+        long totalBidVolume,        // 총 매수잔량
+        List<OrderEntry> asks,      // 매도호가 목록 (1~10)
+        List<OrderEntry> bids       // 매수호가 목록 (1~10)
+) {
+    public record OrderEntry(
+            long price,   // 호가
+            long volume   // 잔량
+    ) {}
+}

--- a/src/main/java/com/sollite/websocket/dto/LsAskingRes.java
+++ b/src/main/java/com/sollite/websocket/dto/LsAskingRes.java
@@ -1,0 +1,66 @@
+package com.sollite.websocket.dto;
+
+import java.util.List;
+
+public record LsAskingRes(
+        LsAskingHeader header,
+        LsAskingBody body
+) {
+    public record LsAskingHeader(
+            String tr_cd
+    ) {}
+
+    public record LsAskingBody(
+            String hotime,
+            String shcode,
+            String volume,
+            String totofferrem,
+            String totbidrem,
+            String offerho1,  String offerho2,  String offerho3,  String offerho4,  String offerho5,
+            String offerho6,  String offerho7,  String offerho8,  String offerho9,  String offerho10,
+            String offerrem1, String offerrem2, String offerrem3, String offerrem4, String offerrem5,
+            String offerrem6, String offerrem7, String offerrem8, String offerrem9, String offerrem10,
+            String bidho1,  String bidho2,  String bidho3,  String bidho4,  String bidho5,
+            String bidho6,  String bidho7,  String bidho8,  String bidho9,  String bidho10,
+            String bidrem1, String bidrem2, String bidrem3, String bidrem4, String bidrem5,
+            String bidrem6, String bidrem7, String bidrem8, String bidrem9, String bidrem10
+    ) {
+        public long parsedTotOfferRem() { return parse(totofferrem()); }
+        public long parsedTotBidRem()   { return parse(totbidrem()); }
+
+        public List<AskingResponse.OrderEntry> toAsks() {
+            return List.of(
+                    new AskingResponse.OrderEntry(parse(offerho1()),  parse(offerrem1())),
+                    new AskingResponse.OrderEntry(parse(offerho2()),  parse(offerrem2())),
+                    new AskingResponse.OrderEntry(parse(offerho3()),  parse(offerrem3())),
+                    new AskingResponse.OrderEntry(parse(offerho4()),  parse(offerrem4())),
+                    new AskingResponse.OrderEntry(parse(offerho5()),  parse(offerrem5())),
+                    new AskingResponse.OrderEntry(parse(offerho6()),  parse(offerrem6())),
+                    new AskingResponse.OrderEntry(parse(offerho7()),  parse(offerrem7())),
+                    new AskingResponse.OrderEntry(parse(offerho8()),  parse(offerrem8())),
+                    new AskingResponse.OrderEntry(parse(offerho9()),  parse(offerrem9())),
+                    new AskingResponse.OrderEntry(parse(offerho10()), parse(offerrem10()))
+            );
+        }
+
+        public List<AskingResponse.OrderEntry> toBids() {
+            return List.of(
+                    new AskingResponse.OrderEntry(parse(bidho1()),  parse(bidrem1())),
+                    new AskingResponse.OrderEntry(parse(bidho2()),  parse(bidrem2())),
+                    new AskingResponse.OrderEntry(parse(bidho3()),  parse(bidrem3())),
+                    new AskingResponse.OrderEntry(parse(bidho4()),  parse(bidrem4())),
+                    new AskingResponse.OrderEntry(parse(bidho5()),  parse(bidrem5())),
+                    new AskingResponse.OrderEntry(parse(bidho6()),  parse(bidrem6())),
+                    new AskingResponse.OrderEntry(parse(bidho7()),  parse(bidrem7())),
+                    new AskingResponse.OrderEntry(parse(bidho8()),  parse(bidrem8())),
+                    new AskingResponse.OrderEntry(parse(bidho9()),  parse(bidrem9())),
+                    new AskingResponse.OrderEntry(parse(bidho10()), parse(bidrem10()))
+            );
+        }
+
+        private long parse(String value) {
+            if (value == null || value.isBlank()) return 0L;
+            try { return Long.parseLong(value.trim()); } catch (NumberFormatException e) { return 0L; }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,4 +99,4 @@ ls:
     appkey: ${LS_APPKEY}
     appsecret: ${LS_APPSECRET}
   ws:
-    url: wss://openapi.ls-sec.co.kr:9443/websocket
+    url: wss://openapi.ls-sec.co.kr:29443/websocket


### PR DESCRIPTION
## 연관된 이슈
> #이슈번호

## 작업 내용
LS증권 OpenAPI H1_ TR을 활용한 실시간 호가 WebSocket 중계 기능을 구현했습니다.

- `/ws/asking/{stockCode}` 엔드포인트로 LS WebSocket 실시간 호가 중계
- `ReactorNettyWebSocketClient`로 LS H1_ TR 구독 후 프론트에 전달
- `ConcurrentWebSocketSessionDecorator`로 멀티스레드 안전 처리
- SecurityConfig에 `/ws/**` permitAll 추가

### 스크린샷 (선택)

## 체크리스트
- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [x] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)
> WebSocket 핸들러 구조 및 LS 구독/해제 방식에 대한 리뷰 부탁드립니다.