### PR TITLE
fix(websocket): UH1 TR 적용 및 tr_key 형식 수정

### DIFF
--- a/src/main/java/com/sollite/websocket/controller/AskingWebSocketHandler.java
+++ b/src/main/java/com/sollite/websocket/controller/AskingWebSocketHandler.java
@@ -33,7 +33,7 @@ public class AskingWebSocketHandler extends TextWebSocketHandler {
     @Value("${ls.ws.url}")
     private String lsWsUrl;
 
-    private static final String TR_CD = "H1_";
+    private static final String TR_CD = "UH1";
     private static final int MAX_SESSIONS = 100;
 
     private final ReactorNettyWebSocketClient lsClient = new ReactorNettyWebSocketClient();
@@ -87,6 +87,7 @@ public class AskingWebSocketHandler extends TextWebSocketHandler {
         String token = lsTokenService.getAccessToken();
 
         Disposable subscription = lsClient.execute(URI.create(lsWsUrl), lsSession -> {
+            log.info("LS WebSocket 연결 성공: sessionId={}", sessionId);
             String subMsg = buildMessage(token, "3", stockCode);
             Mono<Void> send = lsSession.send(
                     Mono.just(lsSession.textMessage(subMsg))
@@ -133,9 +134,10 @@ public class AskingWebSocketHandler extends TextWebSocketHandler {
 
     // LS WebSocket 구독/해제 메시지
     private String buildMessage(String token, String trType, String stockCode) {
+        String trKey = "U" + stockCode + "   ";
         return String.format(
                 "{\"header\":{\"token\":\"%s\",\"tr_type\":\"%s\"},\"body\":{\"tr_cd\":\"%s\",\"tr_key\":\"%s\"}}",
-                token, trType, TR_CD, stockCode
+                token, trType, TR_CD, trKey
         );
     }
 

--- a/src/main/java/com/sollite/websocket/dto/LsAskingRes.java
+++ b/src/main/java/com/sollite/websocket/dto/LsAskingRes.java
@@ -1,60 +1,82 @@
 package com.sollite.websocket.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record LsAskingRes(
         LsAskingHeader header,
         LsAskingBody body
 ) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record LsAskingHeader(
             String tr_cd
     ) {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record LsAskingBody(
             String hotime,
             String shcode,
             String volume,
-            String totofferrem,
-            String totbidrem,
+            @JsonProperty("unt_totofferrem") String untTotofferrem,
+            @JsonProperty("unt_totbidrem")   String untTotbidrem,
             String offerho1,  String offerho2,  String offerho3,  String offerho4,  String offerho5,
             String offerho6,  String offerho7,  String offerho8,  String offerho9,  String offerho10,
-            String offerrem1, String offerrem2, String offerrem3, String offerrem4, String offerrem5,
-            String offerrem6, String offerrem7, String offerrem8, String offerrem9, String offerrem10,
+            @JsonProperty("unt_offerrem1")  String untOfferrem1,
+            @JsonProperty("unt_offerrem2")  String untOfferrem2,
+            @JsonProperty("unt_offerrem3")  String untOfferrem3,
+            @JsonProperty("unt_offerrem4")  String untOfferrem4,
+            @JsonProperty("unt_offerrem5")  String untOfferrem5,
+            @JsonProperty("unt_offerrem6")  String untOfferrem6,
+            @JsonProperty("unt_offerrem7")  String untOfferrem7,
+            @JsonProperty("unt_offerrem8")  String untOfferrem8,
+            @JsonProperty("unt_offerrem9")  String untOfferrem9,
+            @JsonProperty("unt_offerrem10") String untOfferrem10,
             String bidho1,  String bidho2,  String bidho3,  String bidho4,  String bidho5,
             String bidho6,  String bidho7,  String bidho8,  String bidho9,  String bidho10,
-            String bidrem1, String bidrem2, String bidrem3, String bidrem4, String bidrem5,
-            String bidrem6, String bidrem7, String bidrem8, String bidrem9, String bidrem10
+            @JsonProperty("unt_bidrem1")  String untBidrem1,
+            @JsonProperty("unt_bidrem2")  String untBidrem2,
+            @JsonProperty("unt_bidrem3")  String untBidrem3,
+            @JsonProperty("unt_bidrem4")  String untBidrem4,
+            @JsonProperty("unt_bidrem5")  String untBidrem5,
+            @JsonProperty("unt_bidrem6")  String untBidrem6,
+            @JsonProperty("unt_bidrem7")  String untBidrem7,
+            @JsonProperty("unt_bidrem8")  String untBidrem8,
+            @JsonProperty("unt_bidrem9")  String untBidrem9,
+            @JsonProperty("unt_bidrem10") String untBidrem10
     ) {
-        public long parsedTotOfferRem() { return parse(totofferrem()); }
-        public long parsedTotBidRem()   { return parse(totbidrem()); }
+        public long parsedTotOfferRem() { return parse(untTotofferrem()); }
+        public long parsedTotBidRem()   { return parse(untTotbidrem()); }
 
         public List<AskingResponse.OrderEntry> toAsks() {
             return List.of(
-                    new AskingResponse.OrderEntry(parse(offerho1()),  parse(offerrem1())),
-                    new AskingResponse.OrderEntry(parse(offerho2()),  parse(offerrem2())),
-                    new AskingResponse.OrderEntry(parse(offerho3()),  parse(offerrem3())),
-                    new AskingResponse.OrderEntry(parse(offerho4()),  parse(offerrem4())),
-                    new AskingResponse.OrderEntry(parse(offerho5()),  parse(offerrem5())),
-                    new AskingResponse.OrderEntry(parse(offerho6()),  parse(offerrem6())),
-                    new AskingResponse.OrderEntry(parse(offerho7()),  parse(offerrem7())),
-                    new AskingResponse.OrderEntry(parse(offerho8()),  parse(offerrem8())),
-                    new AskingResponse.OrderEntry(parse(offerho9()),  parse(offerrem9())),
-                    new AskingResponse.OrderEntry(parse(offerho10()), parse(offerrem10()))
+                    new AskingResponse.OrderEntry(parse(offerho1()),  parse(untOfferrem1())),
+                    new AskingResponse.OrderEntry(parse(offerho2()),  parse(untOfferrem2())),
+                    new AskingResponse.OrderEntry(parse(offerho3()),  parse(untOfferrem3())),
+                    new AskingResponse.OrderEntry(parse(offerho4()),  parse(untOfferrem4())),
+                    new AskingResponse.OrderEntry(parse(offerho5()),  parse(untOfferrem5())),
+                    new AskingResponse.OrderEntry(parse(offerho6()),  parse(untOfferrem6())),
+                    new AskingResponse.OrderEntry(parse(offerho7()),  parse(untOfferrem7())),
+                    new AskingResponse.OrderEntry(parse(offerho8()),  parse(untOfferrem8())),
+                    new AskingResponse.OrderEntry(parse(offerho9()),  parse(untOfferrem9())),
+                    new AskingResponse.OrderEntry(parse(offerho10()), parse(untOfferrem10()))
             );
         }
 
         public List<AskingResponse.OrderEntry> toBids() {
             return List.of(
-                    new AskingResponse.OrderEntry(parse(bidho1()),  parse(bidrem1())),
-                    new AskingResponse.OrderEntry(parse(bidho2()),  parse(bidrem2())),
-                    new AskingResponse.OrderEntry(parse(bidho3()),  parse(bidrem3())),
-                    new AskingResponse.OrderEntry(parse(bidho4()),  parse(bidrem4())),
-                    new AskingResponse.OrderEntry(parse(bidho5()),  parse(bidrem5())),
-                    new AskingResponse.OrderEntry(parse(bidho6()),  parse(bidrem6())),
-                    new AskingResponse.OrderEntry(parse(bidho7()),  parse(bidrem7())),
-                    new AskingResponse.OrderEntry(parse(bidho8()),  parse(bidrem8())),
-                    new AskingResponse.OrderEntry(parse(bidho9()),  parse(bidrem9())),
-                    new AskingResponse.OrderEntry(parse(bidho10()), parse(bidrem10()))
+                    new AskingResponse.OrderEntry(parse(bidho1()),  parse(untBidrem1())),
+                    new AskingResponse.OrderEntry(parse(bidho2()),  parse(untBidrem2())),
+                    new AskingResponse.OrderEntry(parse(bidho3()),  parse(untBidrem3())),
+                    new AskingResponse.OrderEntry(parse(bidho4()),  parse(untBidrem4())),
+                    new AskingResponse.OrderEntry(parse(bidho5()),  parse(untBidrem5())),
+                    new AskingResponse.OrderEntry(parse(bidho6()),  parse(untBidrem6())),
+                    new AskingResponse.OrderEntry(parse(bidho7()),  parse(untBidrem7())),
+                    new AskingResponse.OrderEntry(parse(bidho8()),  parse(untBidrem8())),
+                    new AskingResponse.OrderEntry(parse(bidho9()),  parse(untBidrem9())),
+                    new AskingResponse.OrderEntry(parse(bidho10()), parse(untBidrem10()))
             );
         }
 


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용
기존 H1_(KOSPI 호가잔량) TR을 UH1(통합 호가잔량)으로 교체하고 tr_key 형식을 수정했습니다.

- H1_ → UH1(통합 호가잔량) TR 변경으로 시간외 단일가 구간 데이터 수신
- tr_key 형식을 `U{종목코드}   ` (7자리 + 공백 3자리) 10자리로 수정
- UH1 응답 필드명(unt_offerrem, unt_bidrem 등)에 맞게 LsAskingRes 수정
- @JsonIgnoreProperties 추가로 불필요한 필드 무시

### 스크린샷 (선택)

## 체크리스트
- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [x] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)
