### PR TITLE
feat(order,balance): 주문/잔고 도메인 구현

### DIFF
--- a/src/main/java/com/sollite/account/controller/AccountController.java
+++ b/src/main/java/com/sollite/account/controller/AccountController.java
@@ -7,6 +7,7 @@ import com.sollite.account.dto.AccountResetResponse;
 import com.sollite.account.dto.PinChangeRequest;
 import com.sollite.account.dto.PinResetConfirmRequest;
 import com.sollite.account.dto.PinVerifyRequest;
+import com.sollite.account.service.AccountCloseFacade;
 import com.sollite.account.service.AccountService;
 import com.sollite.global.util.AuthUtil;
 import com.sollite.user.dto.MessageResponse;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
     private final AccountService accountService;
+    private final AccountCloseFacade accountCloseFacade;
 
     /**
      * 현재 로그인한 사용자의 계좌 정보를 조회합니다.
@@ -133,7 +135,7 @@ public class AccountController {
             Authentication authentication,
             @Valid @RequestBody AccountCloseRequest request) {
         Long userId = AuthUtil.getUserId(authentication);
-        accountService.closeAccount(userId, request.accountPin());
+        accountCloseFacade.closeAccount(userId, request.accountPin());
         return ResponseEntity.ok(new MessageResponse("계좌가 폐쇄되었습니다."));
     }
 }

--- a/src/main/java/com/sollite/account/exception/AccountErrorCode.java
+++ b/src/main/java/com/sollite/account/exception/AccountErrorCode.java
@@ -16,7 +16,8 @@ public enum AccountErrorCode implements ErrorCode {
     PIN_ATTEMPT_EXCEEDED(429, "계좌 비밀번호 시도 횟수를 초과했습니다"),
     ACCOUNT_NOT_ACTIVE(400, "활성화된 계좌가 없습니다"),
     ACCOUNT_CLOSE_BALANCE_REMAINS(400, "예수금 잔고가 남아 있어 계좌를 폐쇄할 수 없습니다"),
-    ACCOUNT_CLOSE_HOLDINGS_REMAIN(400, "보유 종목이 남아 있어 계좌를 폐쇄할 수 없습니다");
+    ACCOUNT_CLOSE_HOLDINGS_REMAIN(400, "보유 종목이 남아 있어 계좌를 폐쇄할 수 없습니다"),
+    ACCOUNT_CLOSE_PENDING_ORDER_EXISTS(400, "미체결 주문이 남아 있어 계좌를 폐쇄할 수 없습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/account/exception/AccountErrorCode.java
+++ b/src/main/java/com/sollite/account/exception/AccountErrorCode.java
@@ -14,7 +14,9 @@ public enum AccountErrorCode implements ErrorCode {
     INVALID_PIN(403, "계좌 비밀번호가 올바르지 않습니다"),
     INVALID_PIN_FORMAT(400, "계좌 비밀번호는 숫자 4자리여야 합니다"),
     PIN_ATTEMPT_EXCEEDED(429, "계좌 비밀번호 시도 횟수를 초과했습니다"),
-    ACCOUNT_NOT_ACTIVE(400, "활성화된 계좌가 없습니다");
+    ACCOUNT_NOT_ACTIVE(400, "활성화된 계좌가 없습니다"),
+    ACCOUNT_CLOSE_BALANCE_REMAINS(400, "예수금 잔고가 남아 있어 계좌를 폐쇄할 수 없습니다"),
+    ACCOUNT_CLOSE_HOLDINGS_REMAIN(400, "보유 종목이 남아 있어 계좌를 폐쇄할 수 없습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/account/service/AccountCloseFacade.java
+++ b/src/main/java/com/sollite/account/service/AccountCloseFacade.java
@@ -1,0 +1,34 @@
+package com.sollite.account.service;
+
+import com.sollite.balance.service.BalanceService;
+import com.sollite.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 계좌 폐쇄를 단일 트랜잭션으로 처리하는 Facade.
+ * AccountService(계좌/PIN 검증), BalanceService(잔고/보유종목 검증),
+ * OrderService(미체결 주문 검증)를 조율합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AccountCloseFacade {
+
+    private final AccountService accountService;
+    private final BalanceService balanceService;
+    private final OrderService orderService;
+
+    @Transactional
+    public void closeAccount(Long userId, String accountPin) {
+        AccountService.CloseContext ctx = accountService.validateAndGetCloseContext(userId, accountPin);
+        Long accountId = ctx.account().getAccountId();
+        Long roundId = ctx.round().getSimulationRoundId();
+
+        balanceService.validateCashForClose(accountId, roundId);
+        balanceService.validateHoldingsForClose(accountId, roundId);
+        orderService.validateNoPendingOrders(accountId, roundId);
+
+        accountService.executeClose(ctx);
+    }
+}

--- a/src/main/java/com/sollite/account/service/AccountService.java
+++ b/src/main/java/com/sollite/account/service/AccountService.java
@@ -13,10 +13,10 @@ import com.sollite.account.exception.AccountErrorCode;
 import com.sollite.balance.domain.entity.CashBalance;
 import com.sollite.balance.domain.repository.CashBalanceRepository;
 import com.sollite.balance.domain.repository.HoldingRepository;
+import com.sollite.balance.exception.BalanceErrorCode;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.order.domain.enums.OrderStatus;
 import com.sollite.order.domain.repository.OrderRepository;
-import com.sollite.order.exception.OrderErrorCode;
 import com.sollite.user.domain.entity.User;
 import com.sollite.user.domain.repository.UserRepository;
 import com.sollite.user.exception.UserErrorCode;
@@ -195,13 +195,13 @@ public class AccountService {
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
 
         // 잔고 > 0 이면 폐쇄 불가
-        cashBalanceRepository.findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
+        CashBalance cb = cashBalanceRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
                         account.getAccountId(), currentRound.getSimulationRoundId(), "KRW")
-                .ifPresent(cb -> {
-                    if (cb.getTotalAmount().compareTo(BigDecimal.ZERO) > 0) {
-                        throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_BALANCE_REMAINS);
-                    }
-                });
+                .orElseThrow(() -> new BusinessException(BalanceErrorCode.CASH_BALANCE_NOT_FOUND));
+        if (cb.getTotalAmount().compareTo(BigDecimal.ZERO) > 0) {
+            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_BALANCE_REMAINS);
+        }
 
         // 보유 주식 있으면 폐쇄 불가
         boolean hasHoldings = holdingRepository
@@ -218,7 +218,7 @@ public class AccountService {
                         account.getAccountId(), currentRound.getSimulationRoundId(), List.of(OrderStatus.PENDING))
                 .isEmpty();
         if (hasPendingOrders) {
-            throw new BusinessException(OrderErrorCode.ORDER_NOT_CANCELLABLE);
+            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_PENDING_ORDER_EXISTS);
         }
 
         currentRound.close(RoundEndReasonCode.ACCOUNT_CLOSED);

--- a/src/main/java/com/sollite/account/service/AccountService.java
+++ b/src/main/java/com/sollite/account/service/AccountService.java
@@ -10,7 +10,13 @@ import com.sollite.account.domain.repository.SimulationRoundRepository;
 import com.sollite.account.dto.AccountInfoResponse;
 import com.sollite.account.dto.AccountResetResponse;
 import com.sollite.account.exception.AccountErrorCode;
+import com.sollite.balance.domain.entity.CashBalance;
+import com.sollite.balance.domain.repository.CashBalanceRepository;
+import com.sollite.balance.domain.repository.HoldingRepository;
 import com.sollite.global.exception.BusinessException;
+import com.sollite.order.domain.enums.OrderStatus;
+import com.sollite.order.domain.repository.OrderRepository;
+import com.sollite.order.exception.OrderErrorCode;
 import com.sollite.user.domain.entity.User;
 import com.sollite.user.domain.repository.UserRepository;
 import com.sollite.user.exception.UserErrorCode;
@@ -21,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Service
@@ -34,6 +41,9 @@ public class AccountService {
     private final UserRepository userRepository;
     private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
+    private final CashBalanceRepository cashBalanceRepository;
+    private final HoldingRepository holdingRepository;
+    private final OrderRepository orderRepository;
 
     /**
      * Facade에서 호출하는 계좌 생성 메서드. 트랜잭션은 Facade가 관리합니다.
@@ -59,6 +69,15 @@ public class AccountService {
                 .build();
 
         simulationRoundRepository.save(round);
+
+        // 초기 현금 잔고 1억원 생성
+        cashBalanceRepository.save(CashBalance.builder()
+                .account(account)
+                .simulationRound(round)
+                .currencyCode("KRW")
+                .availableAmount(SEED_MONEY)
+                .totalAmount(SEED_MONEY)
+                .build());
 
         return account;
     }
@@ -146,7 +165,14 @@ public class AccountService {
 
         simulationRoundRepository.save(newRound);
 
-        // TODO: balance 도메인 구현 후 새 라운드 현금 잔고를 1억원으로 초기화한다.
+        // 새 라운드 현금 잔고 1억원으로 초기화
+        cashBalanceRepository.save(CashBalance.builder()
+                .account(account)
+                .simulationRound(newRound)
+                .currencyCode("KRW")
+                .availableAmount(SEED_MONEY)
+                .totalAmount(SEED_MONEY)
+                .build());
 
         return new AccountResetResponse("시뮬레이션이 초기화되었습니다.", newRound.getRoundNo());
     }
@@ -164,13 +190,36 @@ public class AccountService {
             throw new BusinessException(AccountErrorCode.INVALID_PIN);
         }
 
-        // TODO: 잔고 > 0 이면 폐쇄 불가 — balance 도메인 구현 후 추가 (issue #15)
-        // TODO: 보유 주식/ETF 있으면 폐쇄 불가 — holdings 도메인 구현 후 추가 (issue #15)
-        // TODO: 미체결 주문 있으면 폐쇄 불가 — order 도메인 구현 후 추가 (issue #15)
-
         SimulationRound currentRound = simulationRoundRepository
                 .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+
+        // 잔고 > 0 이면 폐쇄 불가
+        cashBalanceRepository.findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
+                        account.getAccountId(), currentRound.getSimulationRoundId(), "KRW")
+                .ifPresent(cb -> {
+                    if (cb.getTotalAmount().compareTo(BigDecimal.ZERO) > 0) {
+                        throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_BALANCE_REMAINS);
+                    }
+                });
+
+        // 보유 주식 있으면 폐쇄 불가
+        boolean hasHoldings = holdingRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundId(
+                        account.getAccountId(), currentRound.getSimulationRoundId())
+                .stream().anyMatch(h -> h.getHoldingQuantity() > 0);
+        if (hasHoldings) {
+            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_HOLDINGS_REMAIN);
+        }
+
+        // 미체결 주문 있으면 폐쇄 불가
+        boolean hasPendingOrders = !orderRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusIn(
+                        account.getAccountId(), currentRound.getSimulationRoundId(), List.of(OrderStatus.PENDING))
+                .isEmpty();
+        if (hasPendingOrders) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_CANCELLABLE);
+        }
 
         currentRound.close(RoundEndReasonCode.ACCOUNT_CLOSED);
         account.close();

--- a/src/main/java/com/sollite/account/service/AccountService.java
+++ b/src/main/java/com/sollite/account/service/AccountService.java
@@ -10,13 +10,8 @@ import com.sollite.account.domain.repository.SimulationRoundRepository;
 import com.sollite.account.dto.AccountInfoResponse;
 import com.sollite.account.dto.AccountResetResponse;
 import com.sollite.account.exception.AccountErrorCode;
-import com.sollite.balance.domain.entity.CashBalance;
-import com.sollite.balance.domain.repository.CashBalanceRepository;
-import com.sollite.balance.domain.repository.HoldingRepository;
-import com.sollite.balance.exception.BalanceErrorCode;
+import com.sollite.balance.service.BalanceService;
 import com.sollite.global.exception.BusinessException;
-import com.sollite.order.domain.enums.OrderStatus;
-import com.sollite.order.domain.repository.OrderRepository;
 import com.sollite.user.domain.entity.User;
 import com.sollite.user.domain.repository.UserRepository;
 import com.sollite.user.exception.UserErrorCode;
@@ -27,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Service
@@ -41,9 +35,7 @@ public class AccountService {
     private final UserRepository userRepository;
     private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
-    private final CashBalanceRepository cashBalanceRepository;
-    private final HoldingRepository holdingRepository;
-    private final OrderRepository orderRepository;
+    private final BalanceService balanceService;
 
     /**
      * Facade에서 호출하는 계좌 생성 메서드. 트랜잭션은 Facade가 관리합니다.
@@ -71,13 +63,7 @@ public class AccountService {
         simulationRoundRepository.save(round);
 
         // 초기 현금 잔고 1억원 생성
-        cashBalanceRepository.save(CashBalance.builder()
-                .account(account)
-                .simulationRound(round)
-                .currencyCode("KRW")
-                .availableAmount(SEED_MONEY)
-                .totalAmount(SEED_MONEY)
-                .build());
+        balanceService.initializeCashBalance(account, round, SEED_MONEY);
 
         return account;
     }
@@ -166,19 +152,15 @@ public class AccountService {
         simulationRoundRepository.save(newRound);
 
         // 새 라운드 현금 잔고 1억원으로 초기화
-        cashBalanceRepository.save(CashBalance.builder()
-                .account(account)
-                .simulationRound(newRound)
-                .currencyCode("KRW")
-                .availableAmount(SEED_MONEY)
-                .totalAmount(SEED_MONEY)
-                .build());
+        balanceService.initializeCashBalance(account, newRound, SEED_MONEY);
 
         return new AccountResetResponse("시뮬레이션이 초기화되었습니다.", newRound.getRoundNo());
     }
 
+    public record CloseContext(Account account, SimulationRound round) {}
+
     @Transactional
-    public void closeAccount(Long userId, String accountPin) {
+    public CloseContext validateAndGetCloseContext(Long userId, String accountPin) {
         Account account = accountRepository.findByUserIdForUpdate(userId)
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACCOUNT_NOT_FOUND));
 
@@ -194,35 +176,13 @@ public class AccountService {
                 .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
 
-        // 잔고 > 0 이면 폐쇄 불가
-        CashBalance cb = cashBalanceRepository
-                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
-                        account.getAccountId(), currentRound.getSimulationRoundId(), "KRW")
-                .orElseThrow(() -> new BusinessException(BalanceErrorCode.CASH_BALANCE_NOT_FOUND));
-        if (cb.getTotalAmount().compareTo(BigDecimal.ZERO) > 0) {
-            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_BALANCE_REMAINS);
-        }
+        return new CloseContext(account, currentRound);
+    }
 
-        // 보유 주식 있으면 폐쇄 불가
-        boolean hasHoldings = holdingRepository
-                .findByAccount_AccountIdAndSimulationRound_SimulationRoundId(
-                        account.getAccountId(), currentRound.getSimulationRoundId())
-                .stream().anyMatch(h -> h.getHoldingQuantity() > 0);
-        if (hasHoldings) {
-            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_HOLDINGS_REMAIN);
-        }
-
-        // 미체결 주문 있으면 폐쇄 불가
-        boolean hasPendingOrders = !orderRepository
-                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusIn(
-                        account.getAccountId(), currentRound.getSimulationRoundId(), List.of(OrderStatus.PENDING))
-                .isEmpty();
-        if (hasPendingOrders) {
-            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_PENDING_ORDER_EXISTS);
-        }
-
-        currentRound.close(RoundEndReasonCode.ACCOUNT_CLOSED);
-        account.close();
+    @Transactional
+    public void executeClose(CloseContext ctx) {
+        ctx.round().close(RoundEndReasonCode.ACCOUNT_CLOSED);
+        ctx.account().close();
     }
 
     private String generateAccountNo() {

--- a/src/main/java/com/sollite/balance/controller/BalanceController.java
+++ b/src/main/java/com/sollite/balance/controller/BalanceController.java
@@ -1,0 +1,83 @@
+package com.sollite.balance.controller;
+
+import com.sollite.balance.dto.BalanceSummaryResponse;
+import com.sollite.balance.dto.BuyableResponse;
+import com.sollite.balance.dto.CashBalanceResponse;
+import com.sollite.balance.dto.HoldingResponse;
+import com.sollite.balance.dto.PortfolioResponse;
+import com.sollite.balance.service.BalanceService;
+import com.sollite.global.util.AuthUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class BalanceController {
+
+    private final BalanceService balanceService;
+
+    /**
+     * 예수금 조회 (통화별 available / total)
+     */
+    @GetMapping("/api/balance/cash")
+    public ResponseEntity<List<CashBalanceResponse>> getCashBalances(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(balanceService.getCashBalances(userId));
+    }
+
+    /**
+     * 매수 가능 금액
+     */
+    @GetMapping("/api/balance/buyable")
+    public ResponseEntity<BuyableResponse> getBuyableAmount(
+            Authentication authentication,
+            @RequestParam String stockCode,
+            @RequestParam String marketType,
+            @RequestParam(required = false) BigDecimal orderPrice) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(balanceService.getBuyableAmount(userId, stockCode, marketType, orderPrice));
+    }
+
+    /**
+     * 국내 주식 잔고
+     */
+    @GetMapping("/api/balance/stocks")
+    public ResponseEntity<List<HoldingResponse>> getDomesticHoldings(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(balanceService.getDomesticHoldings(userId));
+    }
+
+    /**
+     * 해외 주식 잔고
+     */
+    @GetMapping("/api/balance/stocks/overseas")
+    public ResponseEntity<List<HoldingResponse>> getOverseasHoldings(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(balanceService.getOverseasHoldings(userId));
+    }
+
+    /**
+     * 총 평가자산 요약
+     */
+    @GetMapping("/api/balance/summary")
+    public ResponseEntity<BalanceSummaryResponse> getBalanceSummary(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(balanceService.getBalanceSummary(userId));
+    }
+
+    /**
+     * 포트폴리오 파이차트 구성 비중
+     */
+    @GetMapping("/api/portfolio")
+    public ResponseEntity<PortfolioResponse> getPortfolio(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(balanceService.getPortfolio(userId));
+    }
+}

--- a/src/main/java/com/sollite/balance/domain/entity/CashBalance.java
+++ b/src/main/java/com/sollite/balance/domain/entity/CashBalance.java
@@ -1,0 +1,77 @@
+package com.sollite.balance.domain.entity;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cash_balances")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CashBalance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cash_balance_id")
+    private Long cashBalanceId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "simulation_round_id", nullable = false)
+    private SimulationRound simulationRound;
+
+    @Column(name = "currency_code", nullable = false, length = 3)
+    private String currencyCode;
+
+    @Column(name = "available_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal availableAmount;
+
+    @Column(name = "total_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal totalAmount;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public CashBalance(Account account, SimulationRound simulationRound, String currencyCode,
+                       BigDecimal availableAmount, BigDecimal totalAmount) {
+        this.account = account;
+        this.simulationRound = simulationRound;
+        this.currencyCode = currencyCode;
+        this.availableAmount = availableAmount;
+        this.totalAmount = totalAmount;
+    }
+
+    /** 매수 주문 접수: 가용금액 차감 (total 유지) */
+    public void reserveForBuy(BigDecimal amount) {
+        this.availableAmount = this.availableAmount.subtract(amount);
+    }
+
+    /** 매수 취소/거부: 가용금액 복원 */
+    public void cancelBuyReserve(BigDecimal amount) {
+        this.availableAmount = this.availableAmount.add(amount);
+    }
+
+    /** 매수 체결: total 차감 (available은 접수 시 이미 차감됨) */
+    public void settleForBuy(BigDecimal amount) {
+        this.totalAmount = this.totalAmount.subtract(amount);
+    }
+
+    /** 매도 체결: available + total 모두 증가 */
+    public void settleForSell(BigDecimal proceeds) {
+        this.availableAmount = this.availableAmount.add(proceeds);
+        this.totalAmount = this.totalAmount.add(proceeds);
+    }
+}

--- a/src/main/java/com/sollite/balance/domain/entity/CashLedger.java
+++ b/src/main/java/com/sollite/balance/domain/entity/CashLedger.java
@@ -1,0 +1,71 @@
+package com.sollite.balance.domain.entity;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.balance.domain.enums.CashEntryType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cash_ledger")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CashLedger {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cash_ledger_id")
+    private Long cashLedgerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "simulation_round_id", nullable = false)
+    private SimulationRound simulationRound;
+
+    @Column(name = "currency_code", nullable = false, length = 3)
+    private String currencyCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entry_type", nullable = false, length = 30)
+    private CashEntryType entryType;
+
+    @Column(name = "amount_delta", nullable = false, precision = 19, scale = 4)
+    private BigDecimal amountDelta;
+
+    @Column(name = "balance_after", nullable = false, precision = 19, scale = 4)
+    private BigDecimal balanceAfter;
+
+    @Column(name = "reference_type", nullable = false, length = 30)
+    private String referenceType;
+
+    @Column(name = "reference_id", nullable = false, length = 100)
+    private String referenceId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public CashLedger(Account account, SimulationRound simulationRound, String currencyCode,
+                      CashEntryType entryType, BigDecimal amountDelta, BigDecimal balanceAfter,
+                      String referenceType, String referenceId) {
+        this.account = account;
+        this.simulationRound = simulationRound;
+        this.currencyCode = currencyCode;
+        this.entryType = entryType;
+        this.amountDelta = amountDelta;
+        this.balanceAfter = balanceAfter;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+    }
+}

--- a/src/main/java/com/sollite/balance/domain/entity/Holding.java
+++ b/src/main/java/com/sollite/balance/domain/entity/Holding.java
@@ -1,0 +1,94 @@
+package com.sollite.balance.domain.entity;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.market.domain.entity.Instrument;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "holdings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Holding {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "holding_id")
+    private Long holdingId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "simulation_round_id", nullable = false)
+    private SimulationRound simulationRound;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instrument_id", nullable = false)
+    private Instrument instrument;
+
+    @Column(name = "holding_quantity", nullable = false)
+    private Long holdingQuantity;
+
+    @Column(name = "available_quantity", nullable = false)
+    private Long availableQuantity;
+
+    @Column(name = "avg_buy_price", nullable = false, precision = 19, scale = 4)
+    private BigDecimal avgBuyPrice;
+
+    @Column(name = "avg_buy_exchange_rate", nullable = false, precision = 19, scale = 6)
+    private BigDecimal avgBuyExchangeRate;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Holding(Account account, SimulationRound simulationRound, Instrument instrument,
+                   Long holdingQuantity, Long availableQuantity,
+                   BigDecimal avgBuyPrice, BigDecimal avgBuyExchangeRate) {
+        this.account = account;
+        this.simulationRound = simulationRound;
+        this.instrument = instrument;
+        this.holdingQuantity = holdingQuantity;
+        this.availableQuantity = availableQuantity;
+        this.avgBuyPrice = avgBuyPrice;
+        this.avgBuyExchangeRate = avgBuyExchangeRate != null ? avgBuyExchangeRate : BigDecimal.ONE;
+    }
+
+    /** 매도 주문 접수: 가용수량 차감 */
+    public void reserveForSell(long quantity) {
+        this.availableQuantity -= quantity;
+    }
+
+    /** 매도 취소: 가용수량 복원 */
+    public void cancelSellReserve(long quantity) {
+        this.availableQuantity += quantity;
+    }
+
+    /** 매수 체결: 수량 증가 + 평단가 재계산 */
+    public void addBuyFill(long quantity, BigDecimal fillPrice) {
+        BigDecimal prevTotal = this.avgBuyPrice.multiply(BigDecimal.valueOf(this.holdingQuantity));
+        BigDecimal newTotal = fillPrice.multiply(BigDecimal.valueOf(quantity));
+        long newQty = this.holdingQuantity + quantity;
+        this.avgBuyPrice = prevTotal.add(newTotal)
+                .divide(BigDecimal.valueOf(newQty), 4, RoundingMode.HALF_UP);
+        this.holdingQuantity = newQty;
+        this.availableQuantity += quantity;
+    }
+
+    /** 매도 체결: holding_quantity 차감 (available은 접수 시 이미 차감됨) */
+    public void subtractSellFill(long quantity) {
+        this.holdingQuantity -= quantity;
+    }
+}

--- a/src/main/java/com/sollite/balance/domain/entity/PositionLedger.java
+++ b/src/main/java/com/sollite/balance/domain/entity/PositionLedger.java
@@ -1,0 +1,77 @@
+package com.sollite.balance.domain.entity;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.balance.domain.enums.PositionEntryType;
+import com.sollite.market.domain.entity.Instrument;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "position_ledger")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PositionLedger {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "position_ledger_id")
+    private Long positionLedgerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "simulation_round_id", nullable = false)
+    private SimulationRound simulationRound;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instrument_id", nullable = false)
+    private Instrument instrument;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entry_type", nullable = false, length = 30)
+    private PositionEntryType entryType;
+
+    @Column(name = "quantity_delta", nullable = false)
+    private Long quantityDelta;
+
+    @Column(name = "holding_quantity_after", nullable = false)
+    private Long holdingQuantityAfter;
+
+    @Column(name = "avg_buy_price_after", precision = 19, scale = 4)
+    private BigDecimal avgBuyPriceAfter;
+
+    @Column(name = "reference_type", nullable = false, length = 30)
+    private String referenceType;
+
+    @Column(name = "reference_id", nullable = false, length = 100)
+    private String referenceId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PositionLedger(Account account, SimulationRound simulationRound, Instrument instrument,
+                          PositionEntryType entryType, Long quantityDelta, Long holdingQuantityAfter,
+                          BigDecimal avgBuyPriceAfter, String referenceType, String referenceId) {
+        this.account = account;
+        this.simulationRound = simulationRound;
+        this.instrument = instrument;
+        this.entryType = entryType;
+        this.quantityDelta = quantityDelta;
+        this.holdingQuantityAfter = holdingQuantityAfter;
+        this.avgBuyPriceAfter = avgBuyPriceAfter;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+    }
+}

--- a/src/main/java/com/sollite/balance/domain/entity/package-info.java
+++ b/src/main/java/com/sollite/balance/domain/entity/package-info.java
@@ -1,4 +1,0 @@
-/**
- * com.sollite.balance.domain.entity
- */
-package com.sollite.balance.domain.entity;

--- a/src/main/java/com/sollite/balance/domain/enums/CashEntryType.java
+++ b/src/main/java/com/sollite/balance/domain/enums/CashEntryType.java
@@ -1,0 +1,10 @@
+package com.sollite.balance.domain.enums;
+
+public enum CashEntryType {
+    SEED,               // 초기 시드머니 입금
+    BUY_RESERVE,        // 매수 주문 접수 — 가용금액 차감 (reserved_amount)
+    BUY_RESERVE_CANCEL, // 매수 주문 취소/거부 — 가용금액 복원
+    BUY_SETTLE,         // 매수 체결 — 실제 현금 차감 (total_amount)
+    SELL_SETTLE,        // 매도 체결 — 현금 증가
+    RESET               // 시뮬레이션 초기화
+}

--- a/src/main/java/com/sollite/balance/domain/enums/PositionEntryType.java
+++ b/src/main/java/com/sollite/balance/domain/enums/PositionEntryType.java
@@ -1,0 +1,6 @@
+package com.sollite.balance.domain.enums;
+
+public enum PositionEntryType {
+    BUY_FILL,   // 매수 체결 — 보유수량 증가
+    SELL_FILL   // 매도 체결 — 보유수량 감소
+}

--- a/src/main/java/com/sollite/balance/domain/repository/CashBalanceRepository.java
+++ b/src/main/java/com/sollite/balance/domain/repository/CashBalanceRepository.java
@@ -7,12 +7,16 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CashBalanceRepository extends JpaRepository<CashBalance, Long> {
 
     Optional<CashBalance> findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
             Long accountId, Long simulationRoundId, String currencyCode);
+
+    List<CashBalance> findByAccount_AccountIdAndSimulationRound_SimulationRoundId(
+            Long accountId, Long simulationRoundId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT cb FROM CashBalance cb WHERE cb.account.accountId = :accountId " +

--- a/src/main/java/com/sollite/balance/domain/repository/CashBalanceRepository.java
+++ b/src/main/java/com/sollite/balance/domain/repository/CashBalanceRepository.java
@@ -1,0 +1,23 @@
+package com.sollite.balance.domain.repository;
+
+import com.sollite.balance.domain.entity.CashBalance;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CashBalanceRepository extends JpaRepository<CashBalance, Long> {
+
+    Optional<CashBalance> findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
+            Long accountId, Long simulationRoundId, String currencyCode);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cb FROM CashBalance cb WHERE cb.account.accountId = :accountId " +
+           "AND cb.simulationRound.simulationRoundId = :roundId AND cb.currencyCode = :currencyCode")
+    Optional<CashBalance> findForUpdate(@Param("accountId") Long accountId,
+                                        @Param("roundId") Long roundId,
+                                        @Param("currencyCode") String currencyCode);
+}

--- a/src/main/java/com/sollite/balance/domain/repository/CashLedgerRepository.java
+++ b/src/main/java/com/sollite/balance/domain/repository/CashLedgerRepository.java
@@ -1,0 +1,7 @@
+package com.sollite.balance.domain.repository;
+
+import com.sollite.balance.domain.entity.CashLedger;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CashLedgerRepository extends JpaRepository<CashLedger, Long> {
+}

--- a/src/main/java/com/sollite/balance/domain/repository/HoldingRepository.java
+++ b/src/main/java/com/sollite/balance/domain/repository/HoldingRepository.java
@@ -1,0 +1,28 @@
+package com.sollite.balance.domain.repository;
+
+import com.sollite.balance.domain.entity.Holding;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HoldingRepository extends JpaRepository<Holding, Long> {
+
+    List<Holding> findByAccount_AccountIdAndSimulationRound_SimulationRoundId(
+            Long accountId, Long simulationRoundId);
+
+    Optional<Holding> findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndInstrument_InstrumentId(
+            Long accountId, Long simulationRoundId, Long instrumentId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT h FROM Holding h WHERE h.account.accountId = :accountId " +
+           "AND h.simulationRound.simulationRoundId = :roundId " +
+           "AND h.instrument.instrumentId = :instrumentId")
+    Optional<Holding> findForUpdate(@Param("accountId") Long accountId,
+                                    @Param("roundId") Long roundId,
+                                    @Param("instrumentId") Long instrumentId);
+}

--- a/src/main/java/com/sollite/balance/domain/repository/HoldingRepository.java
+++ b/src/main/java/com/sollite/balance/domain/repository/HoldingRepository.java
@@ -15,6 +15,28 @@ public interface HoldingRepository extends JpaRepository<Holding, Long> {
     List<Holding> findByAccount_AccountIdAndSimulationRound_SimulationRoundId(
             Long accountId, Long simulationRoundId);
 
+    @Query("""
+            SELECT h FROM Holding h
+            JOIN FETCH h.instrument
+            WHERE h.account.accountId = :accountId
+              AND h.simulationRound.simulationRoundId = :roundId
+              AND h.holdingQuantity > 0
+              AND h.instrument.marketType IN :marketTypes
+            """)
+    List<Holding> findActiveHoldings(@Param("accountId") Long accountId,
+                                     @Param("roundId") Long roundId,
+                                     @Param("marketTypes") List<String> marketTypes);
+
+    @Query("""
+            SELECT h FROM Holding h
+            JOIN FETCH h.instrument
+            WHERE h.account.accountId = :accountId
+              AND h.simulationRound.simulationRoundId = :roundId
+              AND h.holdingQuantity > 0
+            """)
+    List<Holding> findAllActiveHoldings(@Param("accountId") Long accountId,
+                                        @Param("roundId") Long roundId);
+
     Optional<Holding> findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndInstrument_InstrumentId(
             Long accountId, Long simulationRoundId, Long instrumentId);
 

--- a/src/main/java/com/sollite/balance/domain/repository/PositionLedgerRepository.java
+++ b/src/main/java/com/sollite/balance/domain/repository/PositionLedgerRepository.java
@@ -1,0 +1,7 @@
+package com.sollite.balance.domain.repository;
+
+import com.sollite.balance.domain.entity.PositionLedger;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PositionLedgerRepository extends JpaRepository<PositionLedger, Long> {
+}

--- a/src/main/java/com/sollite/balance/dto/BalanceSummaryResponse.java
+++ b/src/main/java/com/sollite/balance/dto/BalanceSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.sollite.balance.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record BalanceSummaryResponse(
+        BigDecimal totalCashKrw,
+        BigDecimal totalStockEvaluation,
+        BigDecimal totalAssets,
+        List<CashBalanceResponse> cashBalances,
+        int holdingCount
+) {}

--- a/src/main/java/com/sollite/balance/dto/BuyableResponse.java
+++ b/src/main/java/com/sollite/balance/dto/BuyableResponse.java
@@ -1,0 +1,9 @@
+package com.sollite.balance.dto;
+
+import java.math.BigDecimal;
+
+public record BuyableResponse(
+        BigDecimal availableAmount,
+        BigDecimal orderPrice,
+        Long maxBuyableQuantity
+) {}

--- a/src/main/java/com/sollite/balance/dto/CashBalanceResponse.java
+++ b/src/main/java/com/sollite/balance/dto/CashBalanceResponse.java
@@ -1,0 +1,19 @@
+package com.sollite.balance.dto;
+
+import com.sollite.balance.domain.entity.CashBalance;
+
+import java.math.BigDecimal;
+
+public record CashBalanceResponse(
+        String currencyCode,
+        BigDecimal availableAmount,
+        BigDecimal totalAmount
+) {
+    public static CashBalanceResponse from(CashBalance cb) {
+        return new CashBalanceResponse(
+                cb.getCurrencyCode(),
+                cb.getAvailableAmount(),
+                cb.getTotalAmount()
+        );
+    }
+}

--- a/src/main/java/com/sollite/balance/dto/HoldingResponse.java
+++ b/src/main/java/com/sollite/balance/dto/HoldingResponse.java
@@ -1,0 +1,31 @@
+package com.sollite.balance.dto;
+
+import com.sollite.balance.domain.entity.Holding;
+
+import java.math.BigDecimal;
+
+public record HoldingResponse(
+        Long holdingId,
+        String stockCode,
+        String stockName,
+        String marketType,
+        String currencyCode,
+        Long holdingQuantity,
+        Long availableQuantity,
+        BigDecimal avgBuyPrice,
+        BigDecimal avgBuyExchangeRate
+) {
+    public static HoldingResponse from(Holding h) {
+        return new HoldingResponse(
+                h.getHoldingId(),
+                h.getInstrument().getStockCode(),
+                h.getInstrument().getStockName(),
+                h.getInstrument().getMarketType(),
+                h.getInstrument().getCurrencyCode(),
+                h.getHoldingQuantity(),
+                h.getAvailableQuantity(),
+                h.getAvgBuyPrice(),
+                h.getAvgBuyExchangeRate()
+        );
+    }
+}

--- a/src/main/java/com/sollite/balance/dto/PortfolioItem.java
+++ b/src/main/java/com/sollite/balance/dto/PortfolioItem.java
@@ -1,0 +1,10 @@
+package com.sollite.balance.dto;
+
+import java.math.BigDecimal;
+
+public record PortfolioItem(
+        String label,
+        String type,
+        BigDecimal value,
+        BigDecimal weight
+) {}

--- a/src/main/java/com/sollite/balance/dto/PortfolioResponse.java
+++ b/src/main/java/com/sollite/balance/dto/PortfolioResponse.java
@@ -1,0 +1,9 @@
+package com.sollite.balance.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record PortfolioResponse(
+        BigDecimal totalAssets,
+        List<PortfolioItem> items
+) {}

--- a/src/main/java/com/sollite/balance/exception/BalanceErrorCode.java
+++ b/src/main/java/com/sollite/balance/exception/BalanceErrorCode.java
@@ -1,0 +1,16 @@
+package com.sollite.balance.exception;
+
+import com.sollite.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BalanceErrorCode implements ErrorCode {
+
+    CASH_BALANCE_NOT_FOUND(404, "예수금 정보를 찾을 수 없습니다"),
+    INSTRUMENT_NOT_FOUND(404, "종목을 찾을 수 없습니다");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/sollite/balance/service/BalanceService.java
+++ b/src/main/java/com/sollite/balance/service/BalanceService.java
@@ -46,6 +46,47 @@ public class BalanceService {
     private final MarketService marketService;
     private final ForeignStockMarketService foreignStockMarketService;
 
+    private static final BigDecimal SEED_MONEY = new BigDecimal("100000000");
+
+    /**
+     * 계좌 개설/리셋 시 초기 현금 잔고 생성
+     */
+    @Transactional
+    public void initializeCashBalance(Account account, SimulationRound round, BigDecimal initialAmount) {
+        cashBalanceRepository.save(CashBalance.builder()
+                .account(account)
+                .simulationRound(round)
+                .currencyCode("KRW")
+                .availableAmount(initialAmount)
+                .totalAmount(initialAmount)
+                .build());
+    }
+
+    /**
+     * 계좌 폐쇄 전 현금 잔고 검증 — 잔고 > 0 이면 예외
+     */
+    public void validateCashForClose(Long accountId, Long roundId) {
+        CashBalance cb = cashBalanceRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
+                        accountId, roundId, "KRW")
+                .orElseThrow(() -> new BusinessException(BalanceErrorCode.CASH_BALANCE_NOT_FOUND));
+        if (cb.getTotalAmount().compareTo(BigDecimal.ZERO) > 0) {
+            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_BALANCE_REMAINS);
+        }
+    }
+
+    /**
+     * 계좌 폐쇄 전 보유 종목 검증 — 보유 수량 > 0 이면 예외
+     */
+    public void validateHoldingsForClose(Long accountId, Long roundId) {
+        boolean hasHoldings = holdingRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundId(accountId, roundId)
+                .stream().anyMatch(h -> h.getHoldingQuantity() > 0);
+        if (hasHoldings) {
+            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_HOLDINGS_REMAIN);
+        }
+    }
+
     /**
      * 예수금 조회 (통화별 available / total)
      */
@@ -208,7 +249,7 @@ public class BalanceService {
 
     private BigDecimal fetchCurrentPrice(Instrument instrument) {
         try {
-            if ("FOREIGN".equalsIgnoreCase(instrument.getMarketType())) {
+            if (List.of("NASDAQ", "NYSE", "AMEX").contains(instrument.getMarketType())) {
                 String exchcd = resolveExchangeCode(instrument.getExchangeCode());
                 var response = foreignStockMarketService.getCurrentPrice(instrument.getStockCode(), exchcd);
                 return BigDecimal.valueOf(response.price());

--- a/src/main/java/com/sollite/balance/service/BalanceService.java
+++ b/src/main/java/com/sollite/balance/service/BalanceService.java
@@ -1,0 +1,234 @@
+package com.sollite.balance.service;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.RoundStatus;
+import com.sollite.account.domain.repository.AccountRepository;
+import com.sollite.account.domain.repository.SimulationRoundRepository;
+import com.sollite.account.exception.AccountErrorCode;
+import com.sollite.balance.domain.entity.CashBalance;
+import com.sollite.balance.domain.entity.Holding;
+import com.sollite.balance.domain.repository.CashBalanceRepository;
+import com.sollite.balance.domain.repository.HoldingRepository;
+import com.sollite.balance.dto.BalanceSummaryResponse;
+import com.sollite.balance.dto.BuyableResponse;
+import com.sollite.balance.dto.CashBalanceResponse;
+import com.sollite.balance.dto.HoldingResponse;
+import com.sollite.balance.dto.PortfolioItem;
+import com.sollite.balance.dto.PortfolioResponse;
+import com.sollite.balance.exception.BalanceErrorCode;
+import com.sollite.foreignmarket.service.ForeignStockMarketService;
+import com.sollite.global.exception.BusinessException;
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.market.service.MarketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BalanceService {
+
+    private final AccountRepository accountRepository;
+    private final SimulationRoundRepository simulationRoundRepository;
+    private final CashBalanceRepository cashBalanceRepository;
+    private final HoldingRepository holdingRepository;
+    private final InstrumentRepository instrumentRepository;
+    private final MarketService marketService;
+    private final ForeignStockMarketService foreignStockMarketService;
+
+    /**
+     * 예수금 조회 (통화별 available / total)
+     */
+    public List<CashBalanceResponse> getCashBalances(Long userId) {
+        var pair = resolveAccountAndRound(userId);
+        List<CashBalance> balances = cashBalanceRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundId(
+                        pair.account.getAccountId(), pair.round.getSimulationRoundId());
+        return balances.stream().map(CashBalanceResponse::from).toList();
+    }
+
+    /**
+     * 매수 가능 금액 조회
+     * stockCode + marketType → 종목의 통화 결정 → 해당 통화 가용금액 / 주문가격으로 최대 수량 계산
+     */
+    public BuyableResponse getBuyableAmount(Long userId, String stockCode, String marketType, BigDecimal orderPrice) {
+        var pair = resolveAccountAndRound(userId);
+
+        Instrument instrument = instrumentRepository
+                .findByStockCodeAndMarketType(stockCode, marketType)
+                .orElseThrow(() -> new BusinessException(BalanceErrorCode.INSTRUMENT_NOT_FOUND));
+
+        CashBalance cashBalance = cashBalanceRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndCurrencyCode(
+                        pair.account.getAccountId(), pair.round.getSimulationRoundId(),
+                        instrument.getCurrencyCode())
+                .orElseThrow(() -> new BusinessException(BalanceErrorCode.CASH_BALANCE_NOT_FOUND));
+
+        BigDecimal available = cashBalance.getAvailableAmount();
+
+        // orderPrice가 없으면 현재가 조회
+        BigDecimal price = orderPrice;
+        if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
+            price = fetchCurrentPrice(instrument);
+        }
+
+        long maxQty = 0;
+        if (price != null && price.compareTo(BigDecimal.ZERO) > 0) {
+            maxQty = available.divide(price, 0, RoundingMode.DOWN).longValue();
+        }
+
+        return new BuyableResponse(available, price, maxQty);
+    }
+
+    /**
+     * 국내 주식 잔고
+     */
+    private static final List<String> DOMESTIC_MARKET_TYPES = List.of("KOSPI", "KOSDAQ");
+    private static final List<String> OVERSEAS_MARKET_TYPES = List.of("NASDAQ", "NYSE", "AMEX", "FOREIGN");
+
+    public List<HoldingResponse> getDomesticHoldings(Long userId) {
+        var pair = resolveAccountAndRound(userId);
+        List<Holding> holdings = holdingRepository.findActiveHoldings(
+                pair.account.getAccountId(), pair.round.getSimulationRoundId(), DOMESTIC_MARKET_TYPES);
+        return holdings.stream().map(HoldingResponse::from).toList();
+    }
+
+    /**
+     * 해외 주식 잔고
+     */
+    public List<HoldingResponse> getOverseasHoldings(Long userId) {
+        var pair = resolveAccountAndRound(userId);
+        List<Holding> holdings = holdingRepository.findActiveHoldings(
+                pair.account.getAccountId(), pair.round.getSimulationRoundId(), OVERSEAS_MARKET_TYPES);
+        return holdings.stream().map(HoldingResponse::from).toList();
+    }
+
+    /**
+     * 총 평가자산 요약
+     * - 현금: 모든 통화의 totalAmount 합산 (KRW 기준)
+     * - 주식 평가: holdingQuantity × avgBuyPrice 합산 (매입금액 기준, 실시간 평가는 프론트에서)
+     */
+    public BalanceSummaryResponse getBalanceSummary(Long userId) {
+        var pair = resolveAccountAndRound(userId);
+        Long accountId = pair.account.getAccountId();
+        Long roundId = pair.round.getSimulationRoundId();
+
+        List<CashBalance> cashBalances = cashBalanceRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundId(accountId, roundId);
+
+        BigDecimal totalCash = cashBalances.stream()
+                .map(CashBalance::getTotalAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        List<Holding> holdings = holdingRepository.findAllActiveHoldings(accountId, roundId);
+        BigDecimal totalStockEval = holdings.stream()
+                .map(h -> h.getAvgBuyPrice().multiply(BigDecimal.valueOf(h.getHoldingQuantity())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return new BalanceSummaryResponse(
+                totalCash,
+                totalStockEval,
+                totalCash.add(totalStockEval),
+                cashBalances.stream().map(CashBalanceResponse::from).toList(),
+                holdings.size()
+        );
+    }
+
+    /**
+     * 포트폴리오 파이차트 구성 비중
+     * - 현금 비중 + 종목별 비중 (매입금액 기준)
+     */
+    public PortfolioResponse getPortfolio(Long userId) {
+        var pair = resolveAccountAndRound(userId);
+        Long accountId = pair.account.getAccountId();
+        Long roundId = pair.round.getSimulationRoundId();
+
+        List<CashBalance> cashBalances = cashBalanceRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundId(accountId, roundId);
+        BigDecimal totalCash = cashBalances.stream()
+                .map(CashBalance::getTotalAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        List<Holding> holdings = holdingRepository.findAllActiveHoldings(accountId, roundId);
+        BigDecimal totalStockEval = holdings.stream()
+                .map(h -> h.getAvgBuyPrice().multiply(BigDecimal.valueOf(h.getHoldingQuantity())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal totalAssets = totalCash.add(totalStockEval);
+
+        List<PortfolioItem> items = new ArrayList<>();
+
+        // 현금 항목
+        if (totalCash.compareTo(BigDecimal.ZERO) > 0) {
+            BigDecimal cashWeight = totalAssets.compareTo(BigDecimal.ZERO) > 0
+                    ? totalCash.divide(totalAssets, 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100))
+                    : BigDecimal.ZERO;
+            items.add(new PortfolioItem("현금", "CASH", totalCash, cashWeight));
+        }
+
+        // 종목별 항목
+        for (Holding h : holdings) {
+            BigDecimal evalAmount = h.getAvgBuyPrice().multiply(BigDecimal.valueOf(h.getHoldingQuantity()));
+            BigDecimal weight = totalAssets.compareTo(BigDecimal.ZERO) > 0
+                    ? evalAmount.divide(totalAssets, 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100))
+                    : BigDecimal.ZERO;
+            items.add(new PortfolioItem(
+                    h.getInstrument().getStockName(),
+                    "STOCK",
+                    evalAmount,
+                    weight
+            ));
+        }
+
+        return new PortfolioResponse(totalAssets, items);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private record AccountRound(Account account, SimulationRound round) {}
+
+    private AccountRound resolveAccountAndRound(Long userId) {
+        Account account = accountRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+        SimulationRound round = simulationRoundRepository
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+        return new AccountRound(account, round);
+    }
+
+    private BigDecimal fetchCurrentPrice(Instrument instrument) {
+        try {
+            if ("FOREIGN".equalsIgnoreCase(instrument.getMarketType())) {
+                String exchcd = resolveExchangeCode(instrument.getExchangeCode());
+                var response = foreignStockMarketService.getCurrentPrice(instrument.getStockCode(), exchcd);
+                return BigDecimal.valueOf(response.price());
+            } else {
+                var response = marketService.getCurrentPrice(instrument.getStockCode());
+                return BigDecimal.valueOf(response.currentPrice());
+            }
+        } catch (Exception e) {
+            log.warn("[BALANCE] 현재가 조회 실패 — stockCode={}, error={}",
+                    instrument.getStockCode(), e.getMessage());
+            return null;
+        }
+    }
+
+    private String resolveExchangeCode(String exchangeCode) {
+        if (exchangeCode == null) return "82";
+        return switch (exchangeCode.trim().toUpperCase()) {
+            case "NAS", "NASDAQ", "82" -> "82";
+            case "NYS", "NYSE", "AMS", "AMEX", "81" -> "81";
+            default -> "82";
+        };
+    }
+}

--- a/src/main/java/com/sollite/balance/service/BalanceService.java
+++ b/src/main/java/com/sollite/balance/service/BalanceService.java
@@ -94,7 +94,7 @@ public class BalanceService {
      * 국내 주식 잔고
      */
     private static final List<String> DOMESTIC_MARKET_TYPES = List.of("KOSPI", "KOSDAQ");
-    private static final List<String> OVERSEAS_MARKET_TYPES = List.of("NASDAQ", "NYSE", "AMEX", "FOREIGN");
+    private static final List<String> OVERSEAS_MARKET_TYPES = List.of("NASDAQ", "NYSE", "AMEX");
 
     public List<HoldingResponse> getDomesticHoldings(Long userId) {
         var pair = resolveAccountAndRound(userId);

--- a/src/main/java/com/sollite/global/config/AsyncConfig.java
+++ b/src/main/java/com/sollite/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.sollite.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
@@ -32,4 +32,14 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
     default Optional<String> findFirstExchangeCodeByStockCode(String stockCode) {
         return findExchangeCodesByStockCode(stockCode).stream().findFirst();
     }
+
+    @Query("""
+            SELECT i FROM Instrument i
+            WHERE i.activeYn = 'Y'
+              AND UPPER(i.stockCode) = UPPER(:stockCode)
+              AND i.marketType = :marketType
+            """)
+    Optional<Instrument> findByStockCodeAndMarketType(
+            @Param("stockCode") String stockCode,
+            @Param("marketType") String marketType);
 }

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
@@ -42,4 +42,14 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
     Optional<Instrument> findByStockCodeAndMarketType(
             @Param("stockCode") String stockCode,
             @Param("marketType") String marketType);
+
+    @Query("""
+            SELECT i FROM Instrument i
+            WHERE i.activeYn = 'Y'
+              AND UPPER(i.stockCode) = UPPER(:stockCode)
+              AND i.marketType IN :marketTypes
+            """)
+    Optional<Instrument> findByStockCodeAndMarketTypeIn(
+            @Param("stockCode") String stockCode,
+            @Param("marketTypes") List<String> marketTypes);
 }

--- a/src/main/java/com/sollite/order/controller/OrderController.java
+++ b/src/main/java/com/sollite/order/controller/OrderController.java
@@ -1,0 +1,99 @@
+package com.sollite.order.controller;
+
+import com.sollite.global.util.AuthUtil;
+import com.sollite.order.dto.AmendOrderRequest;
+import com.sollite.order.dto.OrderDetailResponse;
+import com.sollite.order.dto.OrderResponse;
+import com.sollite.order.dto.PlaceOrderRequest;
+import com.sollite.order.service.OrderService;
+import com.sollite.user.dto.MessageResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    /**
+     * 주문 접수 (매수/매도, 지정가/시장가/현재가)
+     */
+    @PostMapping
+    public ResponseEntity<OrderResponse> placeOrder(
+            Authentication authentication,
+            @Valid @RequestBody PlaceOrderRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(orderService.placeOrder(userId, request));
+    }
+
+    /**
+     * 주문내역 조회
+     * @param status ALL | PENDING | FILLED | CANCELLED (기본값: ALL)
+     */
+    @GetMapping
+    public ResponseEntity<List<OrderResponse>> getOrders(
+            Authentication authentication,
+            @RequestParam(defaultValue = "ALL") String status) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(orderService.getOrders(userId, status));
+    }
+
+    /**
+     * 주문 단건 + 체결내역 조회
+     */
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderDetailResponse> getOrderDetail(
+            Authentication authentication,
+            @PathVariable Long orderId) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(orderService.getOrderDetail(userId, orderId));
+    }
+
+    /**
+     * 주문 정정 (PENDING 상태만 가능)
+     */
+    @PatchMapping("/{orderId}")
+    public ResponseEntity<OrderResponse> amendOrder(
+            Authentication authentication,
+            @PathVariable Long orderId,
+            @Valid @RequestBody AmendOrderRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(orderService.amendOrder(userId, orderId, request));
+    }
+
+    /**
+     * 주문 취소
+     */
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<OrderResponse> cancelOrder(
+            Authentication authentication,
+            @PathVariable Long orderId) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(orderService.cancelOrder(userId, orderId));
+    }
+
+    /**
+     * 미체결 주문 전체 취소
+     */
+    @DeleteMapping("/pending/all")
+    public ResponseEntity<MessageResponse> cancelAllPendingOrders(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        int count = orderService.cancelAllPendingOrders(userId);
+        return ResponseEntity.ok(new MessageResponse(count + "건의 미체결 주문이 취소되었습니다."));
+    }
+}

--- a/src/main/java/com/sollite/order/controller/OrderController.java
+++ b/src/main/java/com/sollite/order/controller/OrderController.java
@@ -9,6 +9,7 @@ import com.sollite.order.service.OrderService;
 import com.sollite.user.dto.MessageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -38,7 +39,7 @@ public class OrderController {
             Authentication authentication,
             @Valid @RequestBody PlaceOrderRequest request) {
         Long userId = AuthUtil.getUserId(authentication);
-        return ResponseEntity.ok(orderService.placeOrder(userId, request));
+        return ResponseEntity.status(HttpStatus.CREATED).body(orderService.placeOrder(userId, request));
     }
 
     /**

--- a/src/main/java/com/sollite/order/domain/entity/Execution.java
+++ b/src/main/java/com/sollite/order/domain/entity/Execution.java
@@ -1,0 +1,96 @@
+package com.sollite.order.domain.entity;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.order.domain.enums.OrderSide;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "executions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Execution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "execution_id")
+    private Long executionId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false, unique = true)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "simulation_round_id", nullable = false)
+    private SimulationRound simulationRound;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instrument_id", nullable = false)
+    private Instrument instrument;
+
+    @Column(name = "execution_no", nullable = false, unique = true, length = 40)
+    private String executionNo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_side", nullable = false, length = 10)
+    private OrderSide orderSide;
+
+    @Column(name = "execution_price", nullable = false, precision = 19, scale = 4)
+    private BigDecimal executionPrice;
+
+    @Column(name = "execution_quantity", nullable = false)
+    private Long executionQuantity;
+
+    @Column(name = "gross_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal grossAmount;
+
+    @Column(name = "fee_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal feeAmount;
+
+    @Column(name = "tax_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxAmount;
+
+    @Column(name = "net_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal netAmount;
+
+    @Column(name = "executed_at", nullable = false)
+    private LocalDateTime executedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Execution(Order order, Account account, SimulationRound simulationRound,
+                     Instrument instrument, String executionNo, OrderSide orderSide,
+                     BigDecimal executionPrice, Long executionQuantity,
+                     BigDecimal grossAmount, BigDecimal feeAmount, BigDecimal taxAmount,
+                     BigDecimal netAmount) {
+        this.order = order;
+        this.account = account;
+        this.simulationRound = simulationRound;
+        this.instrument = instrument;
+        this.executionNo = executionNo;
+        this.orderSide = orderSide;
+        this.executionPrice = executionPrice;
+        this.executionQuantity = executionQuantity;
+        this.grossAmount = grossAmount;
+        this.feeAmount = feeAmount;
+        this.taxAmount = taxAmount;
+        this.netAmount = netAmount;
+        this.executedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/sollite/order/domain/entity/Order.java
+++ b/src/main/java/com/sollite/order/domain/entity/Order.java
@@ -1,0 +1,154 @@
+package com.sollite.order.domain.entity;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.order.domain.enums.OrderChannel;
+import com.sollite.order.domain.enums.OrderKind;
+import com.sollite.order.domain.enums.OrderSide;
+import com.sollite.order.domain.enums.OrderStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long orderId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "simulation_round_id", nullable = false)
+    private SimulationRound simulationRound;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instrument_id", nullable = false)
+    private Instrument instrument;
+
+    @Column(name = "order_no", nullable = false, unique = true, length = 40)
+    private String orderNo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_channel", nullable = false, length = 20)
+    private OrderChannel orderChannel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_side", nullable = false, length = 10)
+    private OrderSide orderSide;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_kind", nullable = false, length = 20)
+    private OrderKind orderKind;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status", nullable = false, length = 20)
+    private OrderStatus orderStatus;
+
+    @Column(name = "order_price", precision = 19, scale = 4)
+    private BigDecimal orderPrice;
+
+    @Column(name = "order_quantity", nullable = false)
+    private Long orderQuantity;
+
+    @Column(name = "filled_quantity", nullable = false)
+    private Long filledQuantity;
+
+    @Column(name = "remaining_quantity", nullable = false)
+    private Long remainingQuantity;
+
+    @Column(name = "reserved_amount", precision = 19, scale = 4)
+    private BigDecimal reservedAmount;
+
+    @Column(name = "original_order_id")
+    private Long originalOrderId;
+
+    @Column(name = "idempotency_key", unique = true, length = 100)
+    private String idempotencyKey;
+
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Column(name = "rejected_at")
+    private LocalDateTime rejectedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Order(Account account, SimulationRound simulationRound, Instrument instrument,
+                 String orderNo, OrderChannel orderChannel, OrderSide orderSide,
+                 OrderKind orderKind, BigDecimal orderPrice, Long orderQuantity,
+                 BigDecimal reservedAmount, Long originalOrderId, String idempotencyKey) {
+        this.account = account;
+        this.simulationRound = simulationRound;
+        this.instrument = instrument;
+        this.orderNo = orderNo;
+        this.orderChannel = orderChannel;
+        this.orderSide = orderSide;
+        this.orderKind = orderKind;
+        this.orderStatus = OrderStatus.PENDING;
+        this.orderPrice = orderPrice;
+        this.orderQuantity = orderQuantity;
+        this.filledQuantity = 0L;
+        this.remainingQuantity = orderQuantity;
+        this.reservedAmount = reservedAmount;
+        this.originalOrderId = originalOrderId;
+        this.idempotencyKey = idempotencyKey;
+        this.requestedAt = LocalDateTime.now();
+    }
+
+    public void fill() {
+        this.orderStatus = OrderStatus.FILLED;
+        this.filledQuantity = this.orderQuantity;
+        this.remainingQuantity = 0L;
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        this.orderStatus = OrderStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        this.orderStatus = OrderStatus.REJECTED;
+        this.rejectedAt = LocalDateTime.now();
+    }
+
+    public void amend(BigDecimal newPrice, Long newQuantity, BigDecimal newReservedAmount) {
+        this.orderPrice = newPrice;
+        this.orderQuantity = newQuantity;
+        this.remainingQuantity = newQuantity;
+        this.reservedAmount = newReservedAmount;
+    }
+
+    public boolean isPending() {
+        return this.orderStatus == OrderStatus.PENDING;
+    }
+}

--- a/src/main/java/com/sollite/order/domain/entity/OrderEvent.java
+++ b/src/main/java/com/sollite/order/domain/entity/OrderEvent.java
@@ -1,0 +1,66 @@
+package com.sollite.order.domain.entity;
+
+import com.sollite.order.domain.enums.OrderEventType;
+import com.sollite.order.domain.enums.OrderStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_events")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_event_id")
+    private Long orderEventId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 30)
+    private OrderEventType eventType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "before_status", length = 20)
+    private OrderStatus beforeStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "after_status", nullable = false, length = 20)
+    private OrderStatus afterStatus;
+
+    @Column(name = "reference_type", length = 30)
+    private String referenceType;
+
+    @Column(name = "reference_id", length = 100)
+    private String referenceId;
+
+    @Column(name = "event_message", length = 1000)
+    private String eventMessage;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public OrderEvent(Order order, OrderEventType eventType, OrderStatus beforeStatus,
+                      OrderStatus afterStatus, String referenceType, String referenceId,
+                      String eventMessage) {
+        this.order = order;
+        this.eventType = eventType;
+        this.beforeStatus = beforeStatus;
+        this.afterStatus = afterStatus;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+        this.eventMessage = eventMessage;
+    }
+}

--- a/src/main/java/com/sollite/order/domain/enums/OrderChannel.java
+++ b/src/main/java/com/sollite/order/domain/enums/OrderChannel.java
@@ -1,0 +1,6 @@
+package com.sollite.order.domain.enums;
+
+public enum OrderChannel {
+    CHAT,        // AI 채팅방에서 주문
+    ORDER_FORM   // 주문창에서 직접 주문
+}

--- a/src/main/java/com/sollite/order/domain/enums/OrderEventType.java
+++ b/src/main/java/com/sollite/order/domain/enums/OrderEventType.java
@@ -1,0 +1,9 @@
+package com.sollite.order.domain.enums;
+
+public enum OrderEventType {
+    PLACED,     // 주문 접수
+    FILLED,     // 체결 완료
+    CANCELLED,  // 취소 처리
+    AMENDED,    // 정정 처리
+    REJECTED    // 시스템 거부
+}

--- a/src/main/java/com/sollite/order/domain/enums/OrderKind.java
+++ b/src/main/java/com/sollite/order/domain/enums/OrderKind.java
@@ -1,0 +1,7 @@
+package com.sollite.order.domain.enums;
+
+public enum OrderKind {
+    LIMIT,         // 지정가 — 지정 가격에 도달했을 때 체결
+    MARKET,        // 시장가 — 호가창 기반 즉시 체결
+    CURRENT_PRICE  // 현재가 — 현재 가격에 지정가처럼 접수 후 즉시 체결
+}

--- a/src/main/java/com/sollite/order/domain/enums/OrderSide.java
+++ b/src/main/java/com/sollite/order/domain/enums/OrderSide.java
@@ -1,0 +1,5 @@
+package com.sollite.order.domain.enums;
+
+public enum OrderSide {
+    BUY, SELL
+}

--- a/src/main/java/com/sollite/order/domain/enums/OrderStatus.java
+++ b/src/main/java/com/sollite/order/domain/enums/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.sollite.order.domain.enums;
+
+public enum OrderStatus {
+    PENDING,    // 접수 완료, 체결 대기
+    FILLED,     // 체결 완료
+    CANCELLED,  // 취소됨
+    REJECTED    // 시스템 거부
+}

--- a/src/main/java/com/sollite/order/domain/repository/ExecutionRepository.java
+++ b/src/main/java/com/sollite/order/domain/repository/ExecutionRepository.java
@@ -1,0 +1,11 @@
+package com.sollite.order.domain.repository;
+
+import com.sollite.order.domain.entity.Execution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ExecutionRepository extends JpaRepository<Execution, Long> {
+
+    Optional<Execution> findByOrder_OrderId(Long orderId);
+}

--- a/src/main/java/com/sollite/order/domain/repository/OrderEventRepository.java
+++ b/src/main/java/com/sollite/order/domain/repository/OrderEventRepository.java
@@ -1,0 +1,11 @@
+package com.sollite.order.domain.repository;
+
+import com.sollite.order.domain.entity.OrderEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderEventRepository extends JpaRepository<OrderEvent, Long> {
+
+    List<OrderEvent> findByOrder_OrderIdOrderByCreatedAtAsc(Long orderId);
+}

--- a/src/main/java/com/sollite/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sollite/order/domain/repository/OrderRepository.java
@@ -27,4 +27,21 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT o FROM Order o WHERE o.orderId = :orderId")
     Optional<Order> findByIdForUpdate(@Param("orderId") Long orderId);
+
+    @Query("""
+            SELECT o FROM Order o
+            WHERE o.instrument.instrumentId = :instrumentId
+              AND o.orderStatus = com.sollite.order.domain.enums.OrderStatus.PENDING
+              AND o.orderKind = com.sollite.order.domain.enums.OrderKind.LIMIT
+            ORDER BY o.requestedAt ASC
+            """)
+    List<Order> findPendingLimitOrders(@Param("instrumentId") Long instrumentId);
+
+    @Query("""
+            SELECT o FROM Order o
+            JOIN FETCH o.instrument
+            WHERE o.orderStatus = com.sollite.order.domain.enums.OrderStatus.PENDING
+              AND o.orderKind = com.sollite.order.domain.enums.OrderKind.LIMIT
+            """)
+    List<Order> findAllPendingLimitOrders();
 }

--- a/src/main/java/com/sollite/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sollite/order/domain/repository/OrderRepository.java
@@ -1,0 +1,30 @@
+package com.sollite.order.domain.repository;
+
+import com.sollite.order.domain.entity.Order;
+import com.sollite.order.domain.enums.OrderStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    Optional<Order> findByIdempotencyKey(String idempotencyKey);
+
+    List<Order> findByAccount_AccountIdAndSimulationRound_SimulationRoundIdOrderByRequestedAtDesc(
+            Long accountId, Long simulationRoundId);
+
+    List<Order> findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusOrderByRequestedAtDesc(
+            Long accountId, Long simulationRoundId, OrderStatus orderStatus);
+
+    List<Order> findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusIn(
+            Long accountId, Long simulationRoundId, List<OrderStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Order o WHERE o.orderId = :orderId")
+    Optional<Order> findByIdForUpdate(@Param("orderId") Long orderId);
+}

--- a/src/main/java/com/sollite/order/dto/AmendOrderRequest.java
+++ b/src/main/java/com/sollite/order/dto/AmendOrderRequest.java
@@ -1,0 +1,16 @@
+package com.sollite.order.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record AmendOrderRequest(
+
+        @NotNull(message = "정정 가격은 필수입니다")
+        BigDecimal orderPrice,
+
+        @NotNull(message = "정정 수량은 필수입니다")
+        @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다")
+        Long orderQuantity
+) {}

--- a/src/main/java/com/sollite/order/dto/ExecutionResponse.java
+++ b/src/main/java/com/sollite/order/dto/ExecutionResponse.java
@@ -1,0 +1,35 @@
+package com.sollite.order.dto;
+
+import com.sollite.order.domain.entity.Execution;
+import com.sollite.order.domain.enums.OrderSide;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record ExecutionResponse(
+        Long executionId,
+        String executionNo,
+        OrderSide orderSide,
+        BigDecimal executionPrice,
+        Long executionQuantity,
+        BigDecimal grossAmount,
+        BigDecimal feeAmount,
+        BigDecimal taxAmount,
+        BigDecimal netAmount,
+        LocalDateTime executedAt
+) {
+    public static ExecutionResponse from(Execution execution) {
+        return new ExecutionResponse(
+                execution.getExecutionId(),
+                execution.getExecutionNo(),
+                execution.getOrderSide(),
+                execution.getExecutionPrice(),
+                execution.getExecutionQuantity(),
+                execution.getGrossAmount(),
+                execution.getFeeAmount(),
+                execution.getTaxAmount(),
+                execution.getNetAmount(),
+                execution.getExecutedAt()
+        );
+    }
+}

--- a/src/main/java/com/sollite/order/dto/OrderDetailResponse.java
+++ b/src/main/java/com/sollite/order/dto/OrderDetailResponse.java
@@ -1,0 +1,6 @@
+package com.sollite.order.dto;
+
+public record OrderDetailResponse(
+        OrderResponse order,
+        ExecutionResponse execution  // null이면 미체결
+) {}

--- a/src/main/java/com/sollite/order/dto/OrderResponse.java
+++ b/src/main/java/com/sollite/order/dto/OrderResponse.java
@@ -1,0 +1,48 @@
+package com.sollite.order.dto;
+
+import com.sollite.order.domain.entity.Order;
+import com.sollite.order.domain.enums.OrderChannel;
+import com.sollite.order.domain.enums.OrderKind;
+import com.sollite.order.domain.enums.OrderSide;
+import com.sollite.order.domain.enums.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record OrderResponse(
+        Long orderId,
+        String orderNo,
+        OrderSide orderSide,
+        OrderKind orderKind,
+        OrderChannel orderChannel,
+        OrderStatus orderStatus,
+        Long instrumentId,
+        String stockCode,
+        String stockName,
+        BigDecimal orderPrice,
+        Long orderQuantity,
+        Long filledQuantity,
+        Long remainingQuantity,
+        BigDecimal reservedAmount,
+        LocalDateTime requestedAt
+) {
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(
+                order.getOrderId(),
+                order.getOrderNo(),
+                order.getOrderSide(),
+                order.getOrderKind(),
+                order.getOrderChannel(),
+                order.getOrderStatus(),
+                order.getInstrument().getInstrumentId(),
+                order.getInstrument().getStockCode(),
+                order.getInstrument().getStockName(),
+                order.getOrderPrice(),
+                order.getOrderQuantity(),
+                order.getFilledQuantity(),
+                order.getRemainingQuantity(),
+                order.getReservedAmount(),
+                order.getRequestedAt()
+        );
+    }
+}

--- a/src/main/java/com/sollite/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/com/sollite/order/dto/PlaceOrderRequest.java
@@ -4,14 +4,18 @@ import com.sollite.order.domain.enums.OrderChannel;
 import com.sollite.order.domain.enums.OrderKind;
 import com.sollite.order.domain.enums.OrderSide;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
 public record PlaceOrderRequest(
 
-        @NotNull(message = "종목 ID는 필수입니다")
-        Long instrumentId,
+        @NotBlank(message = "종목 코드는 필수입니다")
+        String stockCode,
+
+        @NotBlank(message = "마켓 구분은 필수입니다")
+        String marketType,
 
         @NotNull(message = "매수/매도 구분은 필수입니다")
         OrderSide orderSide,

--- a/src/main/java/com/sollite/order/dto/PlaceOrderRequest.java
+++ b/src/main/java/com/sollite/order/dto/PlaceOrderRequest.java
@@ -1,0 +1,32 @@
+package com.sollite.order.dto;
+
+import com.sollite.order.domain.enums.OrderChannel;
+import com.sollite.order.domain.enums.OrderKind;
+import com.sollite.order.domain.enums.OrderSide;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record PlaceOrderRequest(
+
+        @NotNull(message = "종목 ID는 필수입니다")
+        Long instrumentId,
+
+        @NotNull(message = "매수/매도 구분은 필수입니다")
+        OrderSide orderSide,
+
+        @NotNull(message = "주문 유형은 필수입니다")
+        OrderKind orderKind,
+
+        @NotNull(message = "주문 채널은 필수입니다")
+        OrderChannel orderChannel,
+
+        BigDecimal orderPrice,  // MARKET 주문 시 null 허용
+
+        @NotNull(message = "주문 수량은 필수입니다")
+        @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다")
+        Long orderQuantity,
+
+        String idempotencyKey  // 선택 — 클라이언트가 중복 방지용 키 직접 제공 시
+) {}

--- a/src/main/java/com/sollite/order/event/MarketTickEvent.java
+++ b/src/main/java/com/sollite/order/event/MarketTickEvent.java
@@ -1,0 +1,21 @@
+package com.sollite.order.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * LS 실시간 시세 틱 수신 시 발행되는 내부 이벤트.
+ * OrderMatchingService가 이 이벤트를 수신하여 PENDING LIMIT 주문 매칭을 수행한다.
+ *
+ * @param symbol     종목코드 (국내: 005930, 해외: AAPL)
+ * @param price      체결가/현재가
+ * @param trCd       LS TR 코드 (US3=국내체결, GSC=해외체결)
+ * @param occurredAt 틱 발생 시각
+ */
+public record MarketTickEvent(
+        String symbol,
+        BigDecimal price,
+        String trCd,
+        Instant occurredAt
+) {
+}

--- a/src/main/java/com/sollite/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/sollite/order/exception/OrderErrorCode.java
@@ -18,7 +18,8 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_ORDER_PRICE(400, "주문 가격이 유효하지 않습니다"),
     INVALID_ORDER_QUANTITY(400, "주문 수량은 1 이상이어야 합니다"),
     DUPLICATE_ORDER(409, "이미 처리된 주문입니다 (중복 요청)"),
-    ORDER_ACCESS_DENIED(403, "본인의 주문만 접근할 수 있습니다");
+    ORDER_ACCESS_DENIED(403, "본인의 주문만 접근할 수 있습니다"),
+    INVALID_ORDER_STATUS(400, "유효하지 않은 주문 상태 값입니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/sollite/order/exception/OrderErrorCode.java
@@ -1,0 +1,25 @@
+package com.sollite.order.exception;
+
+import com.sollite.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    ORDER_NOT_FOUND(404, "주문을 찾을 수 없습니다"),
+    ORDER_NOT_CANCELLABLE(400, "취소 가능한 주문이 아닙니다 (PENDING 상태만 취소 가능)"),
+    ORDER_NOT_AMENDABLE(400, "정정 가능한 주문이 아닙니다 (PENDING 상태만 정정 가능)"),
+    INSUFFICIENT_CASH(400, "매수 가능 금액이 부족합니다"),
+    INSUFFICIENT_HOLDINGS(400, "매도 가능 수량이 부족합니다"),
+    HOLDING_NOT_FOUND(400, "보유하지 않은 종목입니다"),
+    INSTRUMENT_NOT_FOUND(404, "종목을 찾을 수 없습니다"),
+    INVALID_ORDER_PRICE(400, "주문 가격이 유효하지 않습니다"),
+    INVALID_ORDER_QUANTITY(400, "주문 수량은 1 이상이어야 합니다"),
+    DUPLICATE_ORDER(409, "이미 처리된 주문입니다 (중복 요청)"),
+    ORDER_ACCESS_DENIED(403, "본인의 주문만 접근할 수 있습니다");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/sollite/order/service/OrderExecutionService.java
+++ b/src/main/java/com/sollite/order/service/OrderExecutionService.java
@@ -1,0 +1,285 @@
+package com.sollite.order.service;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.exception.AccountErrorCode;
+import com.sollite.balance.domain.entity.CashBalance;
+import com.sollite.balance.domain.entity.CashLedger;
+import com.sollite.balance.domain.entity.Holding;
+import com.sollite.balance.domain.entity.PositionLedger;
+import com.sollite.balance.domain.enums.CashEntryType;
+import com.sollite.balance.domain.enums.PositionEntryType;
+import com.sollite.balance.domain.repository.CashBalanceRepository;
+import com.sollite.balance.domain.repository.CashLedgerRepository;
+import com.sollite.balance.domain.repository.HoldingRepository;
+import com.sollite.balance.domain.repository.PositionLedgerRepository;
+import com.sollite.global.exception.BusinessException;
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.order.domain.entity.Execution;
+import com.sollite.order.domain.entity.Order;
+import com.sollite.order.domain.entity.OrderEvent;
+import com.sollite.order.domain.enums.OrderEventType;
+import com.sollite.order.domain.enums.OrderKind;
+import com.sollite.order.domain.enums.OrderSide;
+import com.sollite.order.domain.enums.OrderStatus;
+import com.sollite.order.domain.repository.ExecutionRepository;
+import com.sollite.order.domain.repository.OrderEventRepository;
+import com.sollite.order.domain.repository.OrderRepository;
+import com.sollite.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 주문 체결 전용 서비스.
+ * 체결(Execution), 원장(CashLedger/PositionLedger), 잔고(CashBalance/Holding) 반영을 여기서만 수행한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderExecutionService {
+
+    private static final DateTimeFormatter EXEC_NO_FMT = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+
+    private final OrderRepository orderRepository;
+    private final ExecutionRepository executionRepository;
+    private final OrderEventRepository orderEventRepository;
+    private final CashBalanceRepository cashBalanceRepository;
+    private final CashLedgerRepository cashLedgerRepository;
+    private final HoldingRepository holdingRepository;
+    private final PositionLedgerRepository positionLedgerRepository;
+
+    /**
+     * 주문 체결 (매수/매도 공통 진입점).
+     * <p>
+     * 1. SELECT FOR UPDATE 으로 Order 락 + PENDING 재검증 (중복 체결 방어)
+     * 2. 매수/매도 분기 후 원장/잔고 반영
+     *
+     * @param orderId   체결 대상 주문 ID
+     * @param fillPrice 체결 가격 (틱 가격 또는 현재가)
+     * @return true 체결 성공, false 이미 체결됨/취소됨 (중복 방어)
+     */
+    @Transactional
+    public boolean execute(Long orderId, BigDecimal fillPrice) {
+        // 1. FOR UPDATE 락 + 상태 재검증
+        Order order = orderRepository.findByIdForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.isPending()) {
+            log.info("[EXEC] 이미 처리된 주문 스킵 — orderId={}, status={}", orderId, order.getOrderStatus());
+            return false;
+        }
+
+        // 2. 매수/매도 분기
+        if (order.getOrderSide() == OrderSide.BUY) {
+            executeBuy(order, fillPrice);
+        } else {
+            executeSell(order, fillPrice);
+        }
+
+        log.info("[EXEC] 체결 완료 — orderId={}, side={}, instrument={}, qty={}, price={}",
+                orderId, order.getOrderSide(), order.getInstrument().getStockCode(),
+                order.getOrderQuantity(), fillPrice);
+
+        return true;
+    }
+
+    // -----------------------------------------------------------------------
+    // 매수 체결
+    // -----------------------------------------------------------------------
+
+    private void executeBuy(Order order, BigDecimal fillPrice) {
+        Account account = order.getAccount();
+        SimulationRound round = order.getSimulationRound();
+        Instrument instrument = order.getInstrument();
+        String currencyCode = instrument.getCurrencyCode();
+
+        BigDecimal cost = fillPrice.multiply(BigDecimal.valueOf(order.getOrderQuantity()));
+
+        // 1. Order → FILLED
+        order.fill();
+
+        // 2. Execution INSERT
+        Execution execution = Execution.builder()
+                .order(order)
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .executionNo(generateExecutionNo())
+                .orderSide(OrderSide.BUY)
+                .executionPrice(fillPrice)
+                .executionQuantity(order.getOrderQuantity())
+                .grossAmount(cost)
+                .feeAmount(BigDecimal.ZERO)
+                .taxAmount(BigDecimal.ZERO)
+                .netAmount(cost)
+                .build();
+        executionRepository.save(execution);
+
+        // 3. CashBalance: 정산
+        CashBalance cashBalance = cashBalanceRepository.findForUpdate(
+                        account.getAccountId(), round.getSimulationRoundId(), currencyCode)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.INSUFFICIENT_CASH));
+
+        // LIMIT 주문: 예약금과 실제 체결금의 차이 조정
+        // 예약금(reservedAmount)은 주문가 기준, 체결금(cost)은 틱가 기준
+        // 예약금 해제 후 실제 체결금으로 정산
+        BigDecimal reservedAmount = order.getReservedAmount();
+        if (reservedAmount != null && reservedAmount.compareTo(BigDecimal.ZERO) > 0) {
+            // available: 예약금 해제 + 실제 체결금 차감
+            // 즉, available += (reservedAmount - cost)
+            BigDecimal refundDiff = reservedAmount.subtract(cost);
+            if (refundDiff.compareTo(BigDecimal.ZERO) != 0) {
+                cashBalance.cancelBuyReserve(refundDiff);
+            }
+        }
+        cashBalance.settleForBuy(cost);
+
+        // 4. CashLedger INSERT (불변 이력)
+        cashLedgerRepository.save(CashLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .currencyCode(currencyCode)
+                .entryType(CashEntryType.BUY_SETTLE)
+                .amountDelta(cost.negate())
+                .balanceAfter(cashBalance.getTotalAmount())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 5. Holdings UPSERT (SELECT FOR UPDATE)
+        Holding holding = holdingRepository
+                .findForUpdate(account.getAccountId(), round.getSimulationRoundId(), instrument.getInstrumentId())
+                .orElseGet(() -> Holding.builder()
+                        .account(account)
+                        .simulationRound(round)
+                        .instrument(instrument)
+                        .holdingQuantity(0L)
+                        .availableQuantity(0L)
+                        .avgBuyPrice(BigDecimal.ZERO)
+                        .avgBuyExchangeRate(BigDecimal.ONE)
+                        .build());
+
+        holding.addBuyFill(order.getOrderQuantity(), fillPrice);
+        holdingRepository.save(holding);
+
+        // 6. PositionLedger INSERT (불변 이력)
+        positionLedgerRepository.save(PositionLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .entryType(PositionEntryType.BUY_FILL)
+                .quantityDelta(order.getOrderQuantity())
+                .holdingQuantityAfter(holding.getHoldingQuantity())
+                .avgBuyPriceAfter(holding.getAvgBuyPrice())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 7. OrderEvent INSERT
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.FILLED)
+                .beforeStatus(OrderStatus.PENDING)
+                .afterStatus(OrderStatus.FILLED)
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+    }
+
+    // -----------------------------------------------------------------------
+    // 매도 체결
+    // -----------------------------------------------------------------------
+
+    private void executeSell(Order order, BigDecimal fillPrice) {
+        Account account = order.getAccount();
+        SimulationRound round = order.getSimulationRound();
+        Instrument instrument = order.getInstrument();
+        String currencyCode = instrument.getCurrencyCode();
+
+        BigDecimal proceeds = fillPrice.multiply(BigDecimal.valueOf(order.getOrderQuantity()));
+
+        // 1. Order → FILLED
+        order.fill();
+
+        // 2. Execution INSERT
+        Execution execution = Execution.builder()
+                .order(order)
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .executionNo(generateExecutionNo())
+                .orderSide(OrderSide.SELL)
+                .executionPrice(fillPrice)
+                .executionQuantity(order.getOrderQuantity())
+                .grossAmount(proceeds)
+                .feeAmount(BigDecimal.ZERO)
+                .taxAmount(BigDecimal.ZERO)
+                .netAmount(proceeds)
+                .build();
+        executionRepository.save(execution);
+
+        // 3. CashBalance UPDATE (available + total 모두 증가)
+        CashBalance cashBalance = cashBalanceRepository.findForUpdate(
+                        account.getAccountId(), round.getSimulationRoundId(), currencyCode)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+        cashBalance.settleForSell(proceeds);
+
+        // 4. CashLedger INSERT (불변 이력)
+        cashLedgerRepository.save(CashLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .currencyCode(currencyCode)
+                .entryType(CashEntryType.SELL_SETTLE)
+                .amountDelta(proceeds)
+                .balanceAfter(cashBalance.getTotalAmount())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 5. Holdings UPDATE: holding_quantity 차감 (available은 접수 시 이미 차감됨)
+        Holding holding = holdingRepository
+                .findForUpdate(account.getAccountId(), round.getSimulationRoundId(), instrument.getInstrumentId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.HOLDING_NOT_FOUND));
+        holding.subtractSellFill(order.getOrderQuantity());
+
+        // 6. PositionLedger INSERT (불변 이력)
+        positionLedgerRepository.save(PositionLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .entryType(PositionEntryType.SELL_FILL)
+                .quantityDelta(-order.getOrderQuantity())
+                .holdingQuantityAfter(holding.getHoldingQuantity())
+                .avgBuyPriceAfter(holding.getAvgBuyPrice())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 7. OrderEvent INSERT
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.FILLED)
+                .beforeStatus(OrderStatus.PENDING)
+                .afterStatus(OrderStatus.FILLED)
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private String generateExecutionNo() {
+        String timestamp = LocalDateTime.now().format(EXEC_NO_FMT);
+        int random = ThreadLocalRandom.current().nextInt(1000, 9999);
+        return "EXE" + timestamp + random;
+    }
+}

--- a/src/main/java/com/sollite/order/service/OrderMatchingService.java
+++ b/src/main/java/com/sollite/order/service/OrderMatchingService.java
@@ -1,0 +1,118 @@
+package com.sollite.order.service;
+
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.order.domain.entity.Order;
+import com.sollite.order.domain.enums.OrderSide;
+import com.sollite.order.domain.repository.OrderRepository;
+import com.sollite.order.event.MarketTickEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 실시간 시세 틱을 수신하여 PENDING LIMIT 주문의 체결 조건을 평가하고,
+ * 조건 충족 시 OrderExecutionService를 호출한다.
+ * <p>
+ * LS 수신 스레드를 블로킹하지 않기 위해 @Async로 처리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderMatchingService {
+
+    private final InstrumentRepository instrumentRepository;
+    private final OrderRepository orderRepository;
+    private final OrderExecutionService orderExecutionService;
+    private final OrderWaitingSubscriptionManager subscriptionManager;
+
+    /**
+     * MarketTickEvent 수신 시 해당 종목의 PENDING LIMIT 주문을 매칭한다.
+     */
+    @Async
+    @EventListener
+    public void onMarketTick(MarketTickEvent event) {
+        String marketType = resolveMarketType(event.trCd());
+
+        Instrument instrument = instrumentRepository
+                .findByStockCodeAndMarketType(event.symbol(), marketType)
+                .orElse(null);
+
+        if (instrument == null) {
+            return;
+        }
+
+        List<Order> candidates = orderRepository.findPendingLimitOrders(instrument.getInstrumentId());
+        if (candidates.isEmpty()) {
+            return;
+        }
+
+        for (Order order : candidates) {
+            if (isMatchable(order, event.price())) {
+                try {
+                    boolean filled = orderExecutionService.execute(order.getOrderId(), event.price());
+                    if (filled) {
+                        subscriptionManager.release(order.getOrderId());
+                        log.info("[MATCH] 체결 — orderId={}, side={}, instrument={}, fillPrice={}",
+                                order.getOrderId(), order.getOrderSide(),
+                                event.symbol(), event.price());
+                    }
+                } catch (Exception e) {
+                    log.error("[MATCH] 체결 실패 — orderId={}, error={}",
+                            order.getOrderId(), e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * 새 LIMIT 주문 접수 직후, 마지막 시세로 즉시 매칭 검사.
+     * 이미 조건 충족이면 다음 틱을 기다리지 않고 바로 체결한다.
+     */
+    public void tryImmediateMatch(Order order, BigDecimal lastPrice) {
+        if (lastPrice == null || lastPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            return;
+        }
+
+        if (isMatchable(order, lastPrice)) {
+            try {
+                boolean filled = orderExecutionService.execute(order.getOrderId(), lastPrice);
+                if (filled) {
+                    subscriptionManager.release(order.getOrderId());
+                    log.info("[MATCH] 즉시 매칭 — orderId={}, side={}, instrument={}, fillPrice={}",
+                            order.getOrderId(), order.getOrderSide(),
+                            order.getInstrument().getStockCode(), lastPrice);
+                }
+            } catch (Exception e) {
+                log.error("[MATCH] 즉시 매칭 실패 — orderId={}, error={}",
+                        order.getOrderId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * 매수: 현재가 <= 지정가 → 체결
+     * 매도: 현재가 >= 지정가 → 체결
+     */
+    private boolean isMatchable(Order order, BigDecimal currentPrice) {
+        return switch (order.getOrderSide()) {
+            case BUY -> currentPrice.compareTo(order.getOrderPrice()) <= 0;
+            case SELL -> currentPrice.compareTo(order.getOrderPrice()) >= 0;
+        };
+    }
+
+    /**
+     * trCd → marketType 변환
+     */
+    private String resolveMarketType(String trCd) {
+        return switch (trCd) {
+            case "GSH", "GSC" -> "FOREIGN";
+            default -> "DOMESTIC";
+        };
+    }
+}

--- a/src/main/java/com/sollite/order/service/OrderMatchingService.java
+++ b/src/main/java/com/sollite/order/service/OrderMatchingService.java
@@ -37,10 +37,10 @@ public class OrderMatchingService {
     @Async
     @EventListener
     public void onMarketTick(MarketTickEvent event) {
-        String marketType = resolveMarketType(event.trCd());
+        List<String> marketTypes = resolveMarketTypes(event.trCd());
 
         Instrument instrument = instrumentRepository
-                .findByStockCodeAndMarketType(event.symbol(), marketType)
+                .findByStockCodeAndMarketTypeIn(event.symbol(), marketTypes)
                 .orElse(null);
 
         if (instrument == null) {
@@ -107,12 +107,13 @@ public class OrderMatchingService {
     }
 
     /**
-     * trCd → marketType 변환
+     * trCd → marketType 목록 변환
+     * US3: KOSPI·KOSDAQ (국내), GSH·GSC: NASDAQ·NYSE·AMEX (해외)
      */
-    private String resolveMarketType(String trCd) {
+    private List<String> resolveMarketTypes(String trCd) {
         return switch (trCd) {
-            case "GSH", "GSC" -> "FOREIGN";
-            default -> "DOMESTIC";
+            case "GSH", "GSC" -> List.of("NASDAQ", "NYSE", "AMEX");
+            default -> List.of("KOSPI", "KOSDAQ");
         };
     }
 }

--- a/src/main/java/com/sollite/order/service/OrderService.java
+++ b/src/main/java/com/sollite/order/service/OrderService.java
@@ -89,8 +89,9 @@ public class OrderService {
                 .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
 
-        // 2. 종목 조회
-        Instrument instrument = instrumentRepository.findById(req.instrumentId())
+        // 2. 종목 조회 (stockCode + marketType → Instrument)
+        Instrument instrument = instrumentRepository
+                .findByStockCodeAndMarketType(req.stockCode(), req.marketType())
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.INSTRUMENT_NOT_FOUND));
 
         // 3. 수량 검증

--- a/src/main/java/com/sollite/order/service/OrderService.java
+++ b/src/main/java/com/sollite/order/service/OrderService.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -70,6 +71,7 @@ public class OrderService {
     private final LsBrokerService lsBrokerService;
     private final MarketService marketService;
     private final ForeignStockMarketService foreignStockMarketService;
+    private final ObjectMapper objectMapper;
 
     // -----------------------------------------------------------------------
     // 주문 접수 (매수/매도 즉시 체결 시뮬레이션)
@@ -268,7 +270,12 @@ public class OrderService {
                     .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdOrderByRequestedAtDesc(
                             account.getAccountId(), round.getSimulationRoundId());
         } else {
-            OrderStatus orderStatus = OrderStatus.valueOf(status.toUpperCase());
+            OrderStatus orderStatus;
+            try {
+                orderStatus = OrderStatus.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS);
+            }
             orders = orderRepository
                     .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusOrderByRequestedAtDesc(
                             account.getAccountId(), round.getSimulationRoundId(), orderStatus);
@@ -495,7 +502,7 @@ public class OrderService {
         String lastJson = lsBrokerService.getLastValue(topic);
         if (lastJson != null) {
             try {
-                var node = new com.fasterxml.jackson.databind.ObjectMapper().readTree(lastJson);
+                var node = objectMapper.readTree(lastJson);
                 if (node.has("price")) {
                     return new BigDecimal(node.get("price").asText().replace(",", "").trim());
                 }

--- a/src/main/java/com/sollite/order/service/OrderService.java
+++ b/src/main/java/com/sollite/order/service/OrderService.java
@@ -377,8 +377,16 @@ public class OrderService {
 
         int count = 0;
         for (Order order : pendingOrders) {
-            cancelOrder(userId, order.getOrderId());
-            count++;
+            try {
+                cancelOrder(userId, order.getOrderId());
+                count++;
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == OrderErrorCode.ORDER_NOT_CANCELLABLE) {
+                    log.info("[ORDER] 취소 스킵 (이미 체결/취소) — orderId={}", order.getOrderId());
+                } else {
+                    throw e;
+                }
+            }
         }
 
         log.info("[ORDER] 미체결 전체 취소 완료 — userId={}, count={}", userId, count);

--- a/src/main/java/com/sollite/order/service/OrderService.java
+++ b/src/main/java/com/sollite/order/service/OrderService.java
@@ -360,6 +360,21 @@ public class OrderService {
     }
 
     // -----------------------------------------------------------------------
+    // 계좌 폐쇄 전 미체결 주문 검증
+    // -----------------------------------------------------------------------
+
+    @Transactional(readOnly = true)
+    public void validateNoPendingOrders(Long accountId, Long roundId) {
+        boolean hasPendingOrders = !orderRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusIn(
+                        accountId, roundId, List.of(OrderStatus.PENDING))
+                .isEmpty();
+        if (hasPendingOrders) {
+            throw new BusinessException(AccountErrorCode.ACCOUNT_CLOSE_PENDING_ORDER_EXISTS);
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // 미체결 전체 취소
     // -----------------------------------------------------------------------
 

--- a/src/main/java/com/sollite/order/service/OrderService.java
+++ b/src/main/java/com/sollite/order/service/OrderService.java
@@ -487,7 +487,7 @@ public class OrderService {
     private BigDecimal resolveLastPrice(Instrument instrument) {
         // 1. 인메모리 캐시에서 먼저 시도
         String topic;
-        if ("FOREIGN".equalsIgnoreCase(instrument.getMarketType())) {
+        if (List.of("NASDAQ", "NYSE", "AMEX").contains(instrument.getMarketType())) {
             topic = "/topic/foreign/transaction/" + instrument.getStockCode();
         } else {
             topic = "/topic/stock/trade/" + instrument.getStockCode();
@@ -513,7 +513,7 @@ public class OrderService {
      */
     private BigDecimal fetchCurrentPrice(Instrument instrument) {
         try {
-            if ("FOREIGN".equalsIgnoreCase(instrument.getMarketType())) {
+            if (List.of("NASDAQ", "NYSE", "AMEX").contains(instrument.getMarketType())) {
                 String exchcd = resolveExchangeCode(instrument.getExchangeCode());
                 var response = foreignStockMarketService.getCurrentPrice(instrument.getStockCode(), exchcd);
                 return BigDecimal.valueOf(response.price());

--- a/src/main/java/com/sollite/order/service/OrderService.java
+++ b/src/main/java/com/sollite/order/service/OrderService.java
@@ -9,20 +9,17 @@ import com.sollite.account.exception.AccountErrorCode;
 import com.sollite.balance.domain.entity.CashBalance;
 import com.sollite.balance.domain.entity.CashLedger;
 import com.sollite.balance.domain.entity.Holding;
-import com.sollite.balance.domain.entity.PositionLedger;
 import com.sollite.balance.domain.enums.CashEntryType;
-import com.sollite.balance.domain.enums.PositionEntryType;
 import com.sollite.balance.domain.repository.CashBalanceRepository;
 import com.sollite.balance.domain.repository.CashLedgerRepository;
 import com.sollite.balance.domain.repository.HoldingRepository;
-import com.sollite.balance.domain.repository.PositionLedgerRepository;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.market.domain.entity.Instrument;
 import com.sollite.market.domain.repository.InstrumentRepository;
-import com.sollite.order.domain.entity.Execution;
 import com.sollite.order.domain.entity.Order;
 import com.sollite.order.domain.entity.OrderEvent;
 import com.sollite.order.domain.enums.OrderEventType;
+import com.sollite.order.domain.enums.OrderKind;
 import com.sollite.order.domain.enums.OrderSide;
 import com.sollite.order.domain.enums.OrderStatus;
 import com.sollite.order.domain.repository.ExecutionRepository;
@@ -34,6 +31,9 @@ import com.sollite.order.dto.OrderDetailResponse;
 import com.sollite.order.dto.OrderResponse;
 import com.sollite.order.dto.PlaceOrderRequest;
 import com.sollite.order.exception.OrderErrorCode;
+import com.sollite.foreignmarket.service.ForeignStockMarketService;
+import com.sollite.market.service.MarketService;
+import com.sollite.websocket.service.LsBrokerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -64,7 +64,12 @@ public class OrderService {
     private final CashBalanceRepository cashBalanceRepository;
     private final CashLedgerRepository cashLedgerRepository;
     private final HoldingRepository holdingRepository;
-    private final PositionLedgerRepository positionLedgerRepository;
+    private final OrderExecutionService orderExecutionService;
+    private final OrderMatchingService orderMatchingService;
+    private final OrderWaitingSubscriptionManager subscriptionManager;
+    private final LsBrokerService lsBrokerService;
+    private final MarketService marketService;
+    private final ForeignStockMarketService foreignStockMarketService;
 
     // -----------------------------------------------------------------------
     // 주문 접수 (매수/매도 즉시 체결 시뮬레이션)
@@ -150,7 +155,19 @@ public class OrderService {
         // 4. 가용금액 차감 (reserve)
         cashBalance.reserveForBuy(cost);
 
-        // 5. OrderEvent: PLACED
+        // 5. CashLedger: BUY_RESERVE
+        cashLedgerRepository.save(CashLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .currencyCode(currencyCode)
+                .entryType(CashEntryType.BUY_RESERVE)
+                .amountDelta(cost.negate())
+                .balanceAfter(cashBalance.getAvailableAmount())
+                .referenceType("ORDER")
+                .referenceId(String.valueOf(order.getOrderId()))
+                .build());
+
+        // 6. OrderEvent: PLACED
         orderEventRepository.save(OrderEvent.builder()
                 .order(order)
                 .eventType(OrderEventType.PLACED)
@@ -158,89 +175,20 @@ public class OrderService {
                 .afterStatus(OrderStatus.PENDING)
                 .build());
 
-        // 6. 즉시 체결 처리
-        fillBuyOrder(order, account, round, instrument, cashBalance, cost, currencyCode, fillPrice);
+        log.info("[ORDER] 매수 주문 접수 — orderId={}, kind={}, instrument={}, qty={}, price={}",
+                order.getOrderId(), req.orderKind(), instrument.getStockCode(), req.orderQuantity(), fillPrice);
 
-        log.info("[ORDER] 매수 체결 완료 — orderId={}, instrument={}, qty={}, price={}",
-                order.getOrderId(), instrument.getStockCode(), req.orderQuantity(), fillPrice);
+        // 7. LIMIT → PENDING 유지 + 구독 hold + 즉시 매칭 검사
+        //    MARKET / CURRENT_PRICE → 즉시 체결
+        if (req.orderKind() == OrderKind.LIMIT) {
+            subscriptionManager.hold(order.getOrderId(), instrument.getMarketType(), instrument.getStockCode());
+            BigDecimal lastPrice = resolveLastPrice(instrument);
+            orderMatchingService.tryImmediateMatch(order, lastPrice);
+        } else {
+            orderExecutionService.execute(order.getOrderId(), fillPrice);
+        }
 
         return OrderResponse.from(order);
-    }
-
-    private void fillBuyOrder(Order order, Account account, SimulationRound round,
-                               Instrument instrument, CashBalance cashBalance,
-                               BigDecimal cost, String currencyCode, BigDecimal fillPrice) {
-        // 1. Order → FILLED
-        order.fill();
-
-        // 2. Execution INSERT
-        Execution execution = Execution.builder()
-                .order(order)
-                .account(account)
-                .simulationRound(round)
-                .instrument(instrument)
-                .executionNo(generateExecutionNo())
-                .orderSide(OrderSide.BUY)
-                .executionPrice(fillPrice)
-                .executionQuantity(order.getOrderQuantity())
-                .grossAmount(cost)
-                .feeAmount(BigDecimal.ZERO)
-                .taxAmount(BigDecimal.ZERO)
-                .netAmount(cost)
-                .build();
-        executionRepository.save(execution);
-
-        // 3. CashLedger: BUY_SETTLE (total 차감)
-        cashBalance.settleForBuy(cost);
-        cashLedgerRepository.save(CashLedger.builder()
-                .account(account)
-                .simulationRound(round)
-                .currencyCode(currencyCode)
-                .entryType(CashEntryType.BUY_SETTLE)
-                .amountDelta(cost.negate())
-                .balanceAfter(cashBalance.getTotalAmount())
-                .referenceType("EXECUTION")
-                .referenceId(String.valueOf(execution.getExecutionId()))
-                .build());
-
-        // 4. Holdings UPSERT (SELECT FOR UPDATE)
-        Holding holding = holdingRepository
-                .findForUpdate(account.getAccountId(), round.getSimulationRoundId(), instrument.getInstrumentId())
-                .orElseGet(() -> Holding.builder()
-                        .account(account)
-                        .simulationRound(round)
-                        .instrument(instrument)
-                        .holdingQuantity(0L)
-                        .availableQuantity(0L)
-                        .avgBuyPrice(BigDecimal.ZERO)
-                        .avgBuyExchangeRate(BigDecimal.ONE)
-                        .build());
-
-        holding.addBuyFill(order.getOrderQuantity(), fillPrice);
-        holdingRepository.save(holding);
-
-        // 5. PositionLedger: BUY_FILL
-        positionLedgerRepository.save(PositionLedger.builder()
-                .account(account)
-                .simulationRound(round)
-                .instrument(instrument)
-                .entryType(PositionEntryType.BUY_FILL)
-                .quantityDelta(order.getOrderQuantity())
-                .holdingQuantityAfter(holding.getHoldingQuantity())
-                .avgBuyPriceAfter(holding.getAvgBuyPrice())
-                .referenceType("EXECUTION")
-                .referenceId(String.valueOf(execution.getExecutionId()))
-                .build());
-
-        // 6. OrderEvent: FILLED
-        orderEventRepository.save(OrderEvent.builder()
-                .order(order)
-                .eventType(OrderEventType.FILLED)
-                .beforeStatus(OrderStatus.PENDING)
-                .afterStatus(OrderStatus.FILLED)
-                .referenceType("EXECUTION")
-                .referenceId(String.valueOf(execution.getExecutionId()))
-                .build());
     }
 
     // -----------------------------------------------------------------------
@@ -249,9 +197,6 @@ public class OrderService {
 
     private OrderResponse processSellOrder(Account account, SimulationRound round, Instrument instrument,
                                            PlaceOrderRequest req, String idempotencyKey, BigDecimal fillPrice) {
-        BigDecimal proceeds = fillPrice.multiply(BigDecimal.valueOf(req.orderQuantity()));
-        String currencyCode = instrument.getCurrencyCode();
-
         // 1. holdings SELECT FOR UPDATE
         Holding holding = holdingRepository
                 .findForUpdate(account.getAccountId(), round.getSimulationRoundId(), instrument.getInstrumentId())
@@ -288,81 +233,20 @@ public class OrderService {
                 .afterStatus(OrderStatus.PENDING)
                 .build());
 
-        // 6. 즉시 체결 처리
-        fillSellOrder(order, account, round, instrument, holding, proceeds, currencyCode, fillPrice);
+        log.info("[ORDER] 매도 주문 접수 — orderId={}, kind={}, instrument={}, qty={}, price={}",
+                order.getOrderId(), req.orderKind(), instrument.getStockCode(), req.orderQuantity(), fillPrice);
 
-        log.info("[ORDER] 매도 체결 완료 — orderId={}, instrument={}, qty={}, price={}",
-                order.getOrderId(), instrument.getStockCode(), req.orderQuantity(), fillPrice);
+        // 6. LIMIT → PENDING 유지 + 구독 hold + 즉시 매칭 검사
+        //    MARKET / CURRENT_PRICE → 즉시 체결
+        if (req.orderKind() == OrderKind.LIMIT) {
+            subscriptionManager.hold(order.getOrderId(), instrument.getMarketType(), instrument.getStockCode());
+            BigDecimal lastPrice = resolveLastPrice(instrument);
+            orderMatchingService.tryImmediateMatch(order, lastPrice);
+        } else {
+            orderExecutionService.execute(order.getOrderId(), fillPrice);
+        }
 
         return OrderResponse.from(order);
-    }
-
-    private void fillSellOrder(Order order, Account account, SimulationRound round,
-                                Instrument instrument, Holding holding,
-                                BigDecimal proceeds, String currencyCode, BigDecimal fillPrice) {
-        // 1. Order → FILLED
-        order.fill();
-
-        // 2. Execution INSERT
-        Execution execution = Execution.builder()
-                .order(order)
-                .account(account)
-                .simulationRound(round)
-                .instrument(instrument)
-                .executionNo(generateExecutionNo())
-                .orderSide(OrderSide.SELL)
-                .executionPrice(fillPrice)
-                .executionQuantity(order.getOrderQuantity())
-                .grossAmount(proceeds)
-                .feeAmount(BigDecimal.ZERO)
-                .taxAmount(BigDecimal.ZERO)
-                .netAmount(proceeds)
-                .build();
-        executionRepository.save(execution);
-
-        // 3. cash_balances UPDATE (available + total 모두 증가)
-        CashBalance cashBalance = cashBalanceRepository.findForUpdate(
-                        account.getAccountId(), round.getSimulationRoundId(), currencyCode)
-                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
-        cashBalance.settleForSell(proceeds);
-
-        // 4. CashLedger: SELL_SETTLE
-        cashLedgerRepository.save(CashLedger.builder()
-                .account(account)
-                .simulationRound(round)
-                .currencyCode(currencyCode)
-                .entryType(CashEntryType.SELL_SETTLE)
-                .amountDelta(proceeds)
-                .balanceAfter(cashBalance.getTotalAmount())
-                .referenceType("EXECUTION")
-                .referenceId(String.valueOf(execution.getExecutionId()))
-                .build());
-
-        // 5. Holdings UPDATE: holding_quantity 차감 (available은 접수 시 이미 차감됨)
-        holding.subtractSellFill(order.getOrderQuantity());
-
-        // 6. PositionLedger: SELL_FILL
-        positionLedgerRepository.save(PositionLedger.builder()
-                .account(account)
-                .simulationRound(round)
-                .instrument(instrument)
-                .entryType(PositionEntryType.SELL_FILL)
-                .quantityDelta(-order.getOrderQuantity())
-                .holdingQuantityAfter(holding.getHoldingQuantity())
-                .avgBuyPriceAfter(holding.getAvgBuyPrice())
-                .referenceType("EXECUTION")
-                .referenceId(String.valueOf(execution.getExecutionId()))
-                .build());
-
-        // 7. OrderEvent: FILLED
-        orderEventRepository.save(OrderEvent.builder()
-                .order(order)
-                .eventType(OrderEventType.FILLED)
-                .beforeStatus(OrderStatus.PENDING)
-                .afterStatus(OrderStatus.FILLED)
-                .referenceType("EXECUTION")
-                .referenceId(String.valueOf(execution.getExecutionId()))
-                .build());
     }
 
     // -----------------------------------------------------------------------
@@ -458,6 +342,11 @@ public class OrderService {
                 .afterStatus(OrderStatus.CANCELLED)
                 .build());
 
+        // LIMIT 주문 구독 해제
+        if (order.getOrderKind() == OrderKind.LIMIT) {
+            subscriptionManager.release(orderId);
+        }
+
         log.info("[ORDER] 주문 취소 완료 — orderId={}", orderId);
         return OrderResponse.from(order);
     }
@@ -547,6 +436,13 @@ public class OrderService {
                 .build());
 
         log.info("[ORDER] 주문 정정 완료 — orderId={}", orderId);
+
+        // 정정 후 즉시 매칭 검사 (가격 변경으로 이미 체결 가능할 수 있음)
+        if (order.getOrderKind() == OrderKind.LIMIT) {
+            BigDecimal lastPrice = resolveLastPrice(instrument);
+            orderMatchingService.tryImmediateMatch(order, lastPrice);
+        }
+
         return OrderResponse.from(order);
     }
 
@@ -555,11 +451,20 @@ public class OrderService {
     // -----------------------------------------------------------------------
 
     private BigDecimal resolveFillPrice(PlaceOrderRequest req, Instrument instrument) {
-        if (req.orderPrice() != null && req.orderPrice().compareTo(BigDecimal.ZERO) > 0) {
+        // LIMIT: 반드시 클라이언트가 가격 지정
+        if (req.orderKind() == OrderKind.LIMIT) {
+            if (req.orderPrice() == null || req.orderPrice().compareTo(BigDecimal.ZERO) <= 0) {
+                throw new BusinessException(OrderErrorCode.INVALID_ORDER_PRICE);
+            }
             return req.orderPrice();
         }
-        // MARKET 주문이고 orderPrice가 null인 경우 — 클라이언트가 가격을 보내지 않으면 예외
-        throw new BusinessException(OrderErrorCode.INVALID_ORDER_PRICE);
+
+        // MARKET / CURRENT_PRICE: 서버가 현재가를 결정한다 (클라이언트 가격 무시)
+        BigDecimal currentPrice = fetchCurrentPrice(instrument);
+        if (currentPrice == null || currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_PRICE);
+        }
+        return currentPrice;
     }
 
     private String resolveIdempotencyKey(String clientKey) {
@@ -575,10 +480,63 @@ public class OrderService {
         return "ORD" + timestamp + random;
     }
 
-    private String generateExecutionNo() {
-        String timestamp = LocalDateTime.now().format(ORDER_NO_FMT);
-        int random = ThreadLocalRandom.current().nextInt(1000, 9999);
-        return "EXE" + timestamp + random;
+    /**
+     * 마지막 시세 조회 (인메모리 캐시 → REST API 폴백)
+     */
+    private BigDecimal resolveLastPrice(Instrument instrument) {
+        // 1. 인메모리 캐시에서 먼저 시도
+        String topic;
+        if ("FOREIGN".equalsIgnoreCase(instrument.getMarketType())) {
+            topic = "/topic/foreign/transaction/" + instrument.getStockCode();
+        } else {
+            topic = "/topic/stock/trade/" + instrument.getStockCode();
+        }
+        String lastJson = lsBrokerService.getLastValue(topic);
+        if (lastJson != null) {
+            try {
+                var node = new com.fasterxml.jackson.databind.ObjectMapper().readTree(lastJson);
+                if (node.has("price")) {
+                    return new BigDecimal(node.get("price").asText().replace(",", "").trim());
+                }
+            } catch (Exception e) {
+                log.warn("[ORDER] lastValue 가격 파싱 실패 — topic={}, error={}", topic, e.getMessage());
+            }
+        }
+
+        // 2. 캐시 미스 → REST API 폴백
+        return fetchCurrentPrice(instrument);
+    }
+
+    /**
+     * LS REST API로 현재가 조회
+     */
+    private BigDecimal fetchCurrentPrice(Instrument instrument) {
+        try {
+            if ("FOREIGN".equalsIgnoreCase(instrument.getMarketType())) {
+                String exchcd = resolveExchangeCode(instrument.getExchangeCode());
+                var response = foreignStockMarketService.getCurrentPrice(instrument.getStockCode(), exchcd);
+                return BigDecimal.valueOf(response.price());
+            } else {
+                var response = marketService.getCurrentPrice(instrument.getStockCode());
+                return BigDecimal.valueOf(response.currentPrice());
+            }
+        } catch (Exception e) {
+            log.warn("[ORDER] REST 현재가 조회 실패 — instrument={}, error={}",
+                    instrument.getStockCode(), e.getMessage());
+            return null;
+        }
+    }
+
+    private String resolveExchangeCode(String exchangeCode) {
+        if (exchangeCode == null) return "82";
+        return switch (exchangeCode.trim().toUpperCase()) {
+            case "NAS", "NASDAQ", "82" -> "82";
+            case "NYS", "NYSE", "AMS", "AMEX", "81" -> "81";
+            default -> {
+                log.warn("[ORDER] 알 수 없는 거래소 코드 — exchangeCode={}", exchangeCode);
+                yield "82";
+            }
+        };
     }
 
     private void validateOwnership(Long userId, Order order) {

--- a/src/main/java/com/sollite/order/service/OrderService.java
+++ b/src/main/java/com/sollite/order/service/OrderService.java
@@ -1,0 +1,589 @@
+package com.sollite.order.service;
+
+import com.sollite.account.domain.entity.Account;
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.RoundStatus;
+import com.sollite.account.domain.repository.AccountRepository;
+import com.sollite.account.domain.repository.SimulationRoundRepository;
+import com.sollite.account.exception.AccountErrorCode;
+import com.sollite.balance.domain.entity.CashBalance;
+import com.sollite.balance.domain.entity.CashLedger;
+import com.sollite.balance.domain.entity.Holding;
+import com.sollite.balance.domain.entity.PositionLedger;
+import com.sollite.balance.domain.enums.CashEntryType;
+import com.sollite.balance.domain.enums.PositionEntryType;
+import com.sollite.balance.domain.repository.CashBalanceRepository;
+import com.sollite.balance.domain.repository.CashLedgerRepository;
+import com.sollite.balance.domain.repository.HoldingRepository;
+import com.sollite.balance.domain.repository.PositionLedgerRepository;
+import com.sollite.global.exception.BusinessException;
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.order.domain.entity.Execution;
+import com.sollite.order.domain.entity.Order;
+import com.sollite.order.domain.entity.OrderEvent;
+import com.sollite.order.domain.enums.OrderEventType;
+import com.sollite.order.domain.enums.OrderSide;
+import com.sollite.order.domain.enums.OrderStatus;
+import com.sollite.order.domain.repository.ExecutionRepository;
+import com.sollite.order.domain.repository.OrderEventRepository;
+import com.sollite.order.domain.repository.OrderRepository;
+import com.sollite.order.dto.AmendOrderRequest;
+import com.sollite.order.dto.ExecutionResponse;
+import com.sollite.order.dto.OrderDetailResponse;
+import com.sollite.order.dto.OrderResponse;
+import com.sollite.order.dto.PlaceOrderRequest;
+import com.sollite.order.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private static final String CURRENCY_KRW = "KRW";
+    private static final DateTimeFormatter ORDER_NO_FMT = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+
+    private final AccountRepository accountRepository;
+    private final SimulationRoundRepository simulationRoundRepository;
+    private final InstrumentRepository instrumentRepository;
+    private final OrderRepository orderRepository;
+    private final OrderEventRepository orderEventRepository;
+    private final ExecutionRepository executionRepository;
+    private final CashBalanceRepository cashBalanceRepository;
+    private final CashLedgerRepository cashLedgerRepository;
+    private final HoldingRepository holdingRepository;
+    private final PositionLedgerRepository positionLedgerRepository;
+
+    // -----------------------------------------------------------------------
+    // 주문 접수 (매수/매도 즉시 체결 시뮬레이션)
+    // -----------------------------------------------------------------------
+
+    @Transactional
+    public OrderResponse placeOrder(Long userId, PlaceOrderRequest req) {
+        // 1. 계좌 & 라운드 조회
+        Account account = accountRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+
+        if (!account.isActive()) {
+            throw new BusinessException(AccountErrorCode.ACCOUNT_NOT_ACTIVE);
+        }
+
+        SimulationRound round = simulationRoundRepository
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+
+        // 2. 종목 조회
+        Instrument instrument = instrumentRepository.findById(req.instrumentId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.INSTRUMENT_NOT_FOUND));
+
+        // 3. 수량 검증
+        if (req.orderQuantity() < 1) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_QUANTITY);
+        }
+
+        // 4. 멱등성 키 중복 체크
+        String idempotencyKey = resolveIdempotencyKey(req.idempotencyKey());
+        Optional<Order> existing = orderRepository.findByIdempotencyKey(idempotencyKey);
+        if (existing.isPresent()) {
+            log.info("[ORDER] 중복 요청 — idempotencyKey={}", idempotencyKey);
+            return OrderResponse.from(existing.get());
+        }
+
+        // 5. 주문 가격 결정
+        BigDecimal fillPrice = resolveFillPrice(req, instrument);
+
+        // 6. 매수/매도 분기 처리
+        if (req.orderSide() == OrderSide.BUY) {
+            return processBuyOrder(account, round, instrument, req, idempotencyKey, fillPrice);
+        } else {
+            return processSellOrder(account, round, instrument, req, idempotencyKey, fillPrice);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 매수 처리
+    // -----------------------------------------------------------------------
+
+    private OrderResponse processBuyOrder(Account account, SimulationRound round, Instrument instrument,
+                                          PlaceOrderRequest req, String idempotencyKey, BigDecimal fillPrice) {
+        BigDecimal cost = fillPrice.multiply(BigDecimal.valueOf(req.orderQuantity()));
+        String currencyCode = instrument.getCurrencyCode();
+
+        // 1. cash_balances SELECT FOR UPDATE
+        CashBalance cashBalance = cashBalanceRepository.findForUpdate(
+                        account.getAccountId(), round.getSimulationRoundId(), currencyCode)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.INSUFFICIENT_CASH));
+
+        // 2. 가용금액 검증
+        if (cashBalance.getAvailableAmount().compareTo(cost) < 0) {
+            throw new BusinessException(OrderErrorCode.INSUFFICIENT_CASH);
+        }
+
+        // 3. 주문 INSERT (PENDING)
+        Order order = Order.builder()
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .orderNo(generateOrderNo())
+                .orderChannel(req.orderChannel())
+                .orderSide(req.orderSide())
+                .orderKind(req.orderKind())
+                .orderPrice(fillPrice)
+                .orderQuantity(req.orderQuantity())
+                .reservedAmount(cost)
+                .idempotencyKey(idempotencyKey)
+                .build();
+        orderRepository.save(order);
+
+        // 4. 가용금액 차감 (reserve)
+        cashBalance.reserveForBuy(cost);
+
+        // 5. OrderEvent: PLACED
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.PLACED)
+                .beforeStatus(null)
+                .afterStatus(OrderStatus.PENDING)
+                .build());
+
+        // 6. 즉시 체결 처리
+        fillBuyOrder(order, account, round, instrument, cashBalance, cost, currencyCode, fillPrice);
+
+        log.info("[ORDER] 매수 체결 완료 — orderId={}, instrument={}, qty={}, price={}",
+                order.getOrderId(), instrument.getStockCode(), req.orderQuantity(), fillPrice);
+
+        return OrderResponse.from(order);
+    }
+
+    private void fillBuyOrder(Order order, Account account, SimulationRound round,
+                               Instrument instrument, CashBalance cashBalance,
+                               BigDecimal cost, String currencyCode, BigDecimal fillPrice) {
+        // 1. Order → FILLED
+        order.fill();
+
+        // 2. Execution INSERT
+        Execution execution = Execution.builder()
+                .order(order)
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .executionNo(generateExecutionNo())
+                .orderSide(OrderSide.BUY)
+                .executionPrice(fillPrice)
+                .executionQuantity(order.getOrderQuantity())
+                .grossAmount(cost)
+                .feeAmount(BigDecimal.ZERO)
+                .taxAmount(BigDecimal.ZERO)
+                .netAmount(cost)
+                .build();
+        executionRepository.save(execution);
+
+        // 3. CashLedger: BUY_SETTLE (total 차감)
+        cashBalance.settleForBuy(cost);
+        cashLedgerRepository.save(CashLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .currencyCode(currencyCode)
+                .entryType(CashEntryType.BUY_SETTLE)
+                .amountDelta(cost.negate())
+                .balanceAfter(cashBalance.getTotalAmount())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 4. Holdings UPSERT (SELECT FOR UPDATE)
+        Holding holding = holdingRepository
+                .findForUpdate(account.getAccountId(), round.getSimulationRoundId(), instrument.getInstrumentId())
+                .orElseGet(() -> Holding.builder()
+                        .account(account)
+                        .simulationRound(round)
+                        .instrument(instrument)
+                        .holdingQuantity(0L)
+                        .availableQuantity(0L)
+                        .avgBuyPrice(BigDecimal.ZERO)
+                        .avgBuyExchangeRate(BigDecimal.ONE)
+                        .build());
+
+        holding.addBuyFill(order.getOrderQuantity(), fillPrice);
+        holdingRepository.save(holding);
+
+        // 5. PositionLedger: BUY_FILL
+        positionLedgerRepository.save(PositionLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .entryType(PositionEntryType.BUY_FILL)
+                .quantityDelta(order.getOrderQuantity())
+                .holdingQuantityAfter(holding.getHoldingQuantity())
+                .avgBuyPriceAfter(holding.getAvgBuyPrice())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 6. OrderEvent: FILLED
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.FILLED)
+                .beforeStatus(OrderStatus.PENDING)
+                .afterStatus(OrderStatus.FILLED)
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+    }
+
+    // -----------------------------------------------------------------------
+    // 매도 처리
+    // -----------------------------------------------------------------------
+
+    private OrderResponse processSellOrder(Account account, SimulationRound round, Instrument instrument,
+                                           PlaceOrderRequest req, String idempotencyKey, BigDecimal fillPrice) {
+        BigDecimal proceeds = fillPrice.multiply(BigDecimal.valueOf(req.orderQuantity()));
+        String currencyCode = instrument.getCurrencyCode();
+
+        // 1. holdings SELECT FOR UPDATE
+        Holding holding = holdingRepository
+                .findForUpdate(account.getAccountId(), round.getSimulationRoundId(), instrument.getInstrumentId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.HOLDING_NOT_FOUND));
+
+        // 2. 가용수량 검증
+        if (holding.getAvailableQuantity() < req.orderQuantity()) {
+            throw new BusinessException(OrderErrorCode.INSUFFICIENT_HOLDINGS);
+        }
+
+        // 3. 주문 INSERT (PENDING)
+        Order order = Order.builder()
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .orderNo(generateOrderNo())
+                .orderChannel(req.orderChannel())
+                .orderSide(req.orderSide())
+                .orderKind(req.orderKind())
+                .orderPrice(fillPrice)
+                .orderQuantity(req.orderQuantity())
+                .idempotencyKey(idempotencyKey)
+                .build();
+        orderRepository.save(order);
+
+        // 4. 가용수량 차감 (reserve)
+        holding.reserveForSell(req.orderQuantity());
+
+        // 5. OrderEvent: PLACED
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.PLACED)
+                .beforeStatus(null)
+                .afterStatus(OrderStatus.PENDING)
+                .build());
+
+        // 6. 즉시 체결 처리
+        fillSellOrder(order, account, round, instrument, holding, proceeds, currencyCode, fillPrice);
+
+        log.info("[ORDER] 매도 체결 완료 — orderId={}, instrument={}, qty={}, price={}",
+                order.getOrderId(), instrument.getStockCode(), req.orderQuantity(), fillPrice);
+
+        return OrderResponse.from(order);
+    }
+
+    private void fillSellOrder(Order order, Account account, SimulationRound round,
+                                Instrument instrument, Holding holding,
+                                BigDecimal proceeds, String currencyCode, BigDecimal fillPrice) {
+        // 1. Order → FILLED
+        order.fill();
+
+        // 2. Execution INSERT
+        Execution execution = Execution.builder()
+                .order(order)
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .executionNo(generateExecutionNo())
+                .orderSide(OrderSide.SELL)
+                .executionPrice(fillPrice)
+                .executionQuantity(order.getOrderQuantity())
+                .grossAmount(proceeds)
+                .feeAmount(BigDecimal.ZERO)
+                .taxAmount(BigDecimal.ZERO)
+                .netAmount(proceeds)
+                .build();
+        executionRepository.save(execution);
+
+        // 3. cash_balances UPDATE (available + total 모두 증가)
+        CashBalance cashBalance = cashBalanceRepository.findForUpdate(
+                        account.getAccountId(), round.getSimulationRoundId(), currencyCode)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+        cashBalance.settleForSell(proceeds);
+
+        // 4. CashLedger: SELL_SETTLE
+        cashLedgerRepository.save(CashLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .currencyCode(currencyCode)
+                .entryType(CashEntryType.SELL_SETTLE)
+                .amountDelta(proceeds)
+                .balanceAfter(cashBalance.getTotalAmount())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 5. Holdings UPDATE: holding_quantity 차감 (available은 접수 시 이미 차감됨)
+        holding.subtractSellFill(order.getOrderQuantity());
+
+        // 6. PositionLedger: SELL_FILL
+        positionLedgerRepository.save(PositionLedger.builder()
+                .account(account)
+                .simulationRound(round)
+                .instrument(instrument)
+                .entryType(PositionEntryType.SELL_FILL)
+                .quantityDelta(-order.getOrderQuantity())
+                .holdingQuantityAfter(holding.getHoldingQuantity())
+                .avgBuyPriceAfter(holding.getAvgBuyPrice())
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+
+        // 7. OrderEvent: FILLED
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.FILLED)
+                .beforeStatus(OrderStatus.PENDING)
+                .afterStatus(OrderStatus.FILLED)
+                .referenceType("EXECUTION")
+                .referenceId(String.valueOf(execution.getExecutionId()))
+                .build());
+    }
+
+    // -----------------------------------------------------------------------
+    // 주문 조회
+    // -----------------------------------------------------------------------
+
+    @Transactional(readOnly = true)
+    public List<OrderResponse> getOrders(Long userId, String status) {
+        Account account = accountRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+        SimulationRound round = simulationRoundRepository
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+
+        List<Order> orders;
+        if ("ALL".equalsIgnoreCase(status) || status == null) {
+            orders = orderRepository
+                    .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdOrderByRequestedAtDesc(
+                            account.getAccountId(), round.getSimulationRoundId());
+        } else {
+            OrderStatus orderStatus = OrderStatus.valueOf(status.toUpperCase());
+            orders = orderRepository
+                    .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusOrderByRequestedAtDesc(
+                            account.getAccountId(), round.getSimulationRoundId(), orderStatus);
+        }
+
+        return orders.stream().map(OrderResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public OrderDetailResponse getOrderDetail(Long userId, Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        validateOwnership(userId, order);
+
+        ExecutionResponse executionResponse = executionRepository.findByOrder_OrderId(orderId)
+                .map(ExecutionResponse::from)
+                .orElse(null);
+
+        return new OrderDetailResponse(OrderResponse.from(order), executionResponse);
+    }
+
+    // -----------------------------------------------------------------------
+    // 주문 취소
+    // -----------------------------------------------------------------------
+
+    @Transactional
+    public OrderResponse cancelOrder(Long userId, Long orderId) {
+        Order order = orderRepository.findByIdForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        validateOwnership(userId, order);
+
+        if (!order.isPending()) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_CANCELLABLE);
+        }
+
+        Account account = order.getAccount();
+        SimulationRound round = order.getSimulationRound();
+        Instrument instrument = order.getInstrument();
+
+        if (order.getOrderSide() == OrderSide.BUY) {
+            // 매수 취소: 가용금액 복원
+            CashBalance cashBalance = cashBalanceRepository.findForUpdate(
+                            account.getAccountId(), round.getSimulationRoundId(), instrument.getCurrencyCode())
+                    .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+            cashBalance.cancelBuyReserve(order.getReservedAmount());
+
+            cashLedgerRepository.save(CashLedger.builder()
+                    .account(account)
+                    .simulationRound(round)
+                    .currencyCode(instrument.getCurrencyCode())
+                    .entryType(CashEntryType.BUY_RESERVE_CANCEL)
+                    .amountDelta(order.getReservedAmount())
+                    .balanceAfter(cashBalance.getAvailableAmount())
+                    .referenceType("ORDER")
+                    .referenceId(String.valueOf(orderId))
+                    .build());
+        } else {
+            // 매도 취소: 가용수량 복원
+            holdingRepository.findForUpdate(account.getAccountId(), round.getSimulationRoundId(),
+                            instrument.getInstrumentId())
+                    .ifPresent(h -> h.cancelSellReserve(order.getOrderQuantity()));
+        }
+
+        order.cancel();
+
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.CANCELLED)
+                .beforeStatus(OrderStatus.PENDING)
+                .afterStatus(OrderStatus.CANCELLED)
+                .build());
+
+        log.info("[ORDER] 주문 취소 완료 — orderId={}", orderId);
+        return OrderResponse.from(order);
+    }
+
+    // -----------------------------------------------------------------------
+    // 미체결 전체 취소
+    // -----------------------------------------------------------------------
+
+    @Transactional
+    public int cancelAllPendingOrders(Long userId) {
+        Account account = accountRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACCOUNT_NOT_FOUND));
+        SimulationRound round = simulationRoundRepository
+                .findByAccount_AccountIdAndRoundStatus(account.getAccountId(), RoundStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+
+        List<Order> pendingOrders = orderRepository
+                .findByAccount_AccountIdAndSimulationRound_SimulationRoundIdAndOrderStatusIn(
+                        account.getAccountId(), round.getSimulationRoundId(), List.of(OrderStatus.PENDING));
+
+        int count = 0;
+        for (Order order : pendingOrders) {
+            cancelOrder(userId, order.getOrderId());
+            count++;
+        }
+
+        log.info("[ORDER] 미체결 전체 취소 완료 — userId={}, count={}", userId, count);
+        return count;
+    }
+
+    // -----------------------------------------------------------------------
+    // 주문 정정 (PENDING 상태의 LIMIT 주문만)
+    // -----------------------------------------------------------------------
+
+    @Transactional
+    public OrderResponse amendOrder(Long userId, Long orderId, AmendOrderRequest req) {
+        Order order = orderRepository.findByIdForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        validateOwnership(userId, order);
+
+        if (!order.isPending()) {
+            throw new BusinessException(OrderErrorCode.ORDER_NOT_AMENDABLE);
+        }
+
+        Account account = order.getAccount();
+        SimulationRound round = order.getSimulationRound();
+        Instrument instrument = order.getInstrument();
+        BigDecimal newCost = req.orderPrice().multiply(BigDecimal.valueOf(req.orderQuantity()));
+
+        if (order.getOrderSide() == OrderSide.BUY) {
+            CashBalance cashBalance = cashBalanceRepository.findForUpdate(
+                            account.getAccountId(), round.getSimulationRoundId(), instrument.getCurrencyCode())
+                    .orElseThrow(() -> new BusinessException(AccountErrorCode.ACTIVE_ROUND_NOT_FOUND));
+
+            // 기존 예약금 복원 후 새 금액 검증
+            BigDecimal adjustedAvailable = cashBalance.getAvailableAmount().add(order.getReservedAmount());
+            if (adjustedAvailable.compareTo(newCost) < 0) {
+                throw new BusinessException(OrderErrorCode.INSUFFICIENT_CASH);
+            }
+
+            // available 재계산
+            cashBalance.cancelBuyReserve(order.getReservedAmount());
+            cashBalance.reserveForBuy(newCost);
+        } else {
+            Holding holding = holdingRepository.findForUpdate(
+                            account.getAccountId(), round.getSimulationRoundId(), instrument.getInstrumentId())
+                    .orElseThrow(() -> new BusinessException(OrderErrorCode.HOLDING_NOT_FOUND));
+
+            long adjustedAvailable = holding.getAvailableQuantity() + order.getOrderQuantity();
+            if (adjustedAvailable < req.orderQuantity()) {
+                throw new BusinessException(OrderErrorCode.INSUFFICIENT_HOLDINGS);
+            }
+
+            holding.cancelSellReserve(order.getOrderQuantity());
+            holding.reserveForSell(req.orderQuantity());
+        }
+
+        order.amend(req.orderPrice(), req.orderQuantity(), newCost);
+
+        orderEventRepository.save(OrderEvent.builder()
+                .order(order)
+                .eventType(OrderEventType.AMENDED)
+                .beforeStatus(OrderStatus.PENDING)
+                .afterStatus(OrderStatus.PENDING)
+                .eventMessage("정정: price=" + req.orderPrice() + ", qty=" + req.orderQuantity())
+                .build());
+
+        log.info("[ORDER] 주문 정정 완료 — orderId={}", orderId);
+        return OrderResponse.from(order);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private BigDecimal resolveFillPrice(PlaceOrderRequest req, Instrument instrument) {
+        if (req.orderPrice() != null && req.orderPrice().compareTo(BigDecimal.ZERO) > 0) {
+            return req.orderPrice();
+        }
+        // MARKET 주문이고 orderPrice가 null인 경우 — 클라이언트가 가격을 보내지 않으면 예외
+        throw new BusinessException(OrderErrorCode.INVALID_ORDER_PRICE);
+    }
+
+    private String resolveIdempotencyKey(String clientKey) {
+        if (clientKey != null && !clientKey.isBlank()) {
+            return clientKey;
+        }
+        return UUID.randomUUID().toString();
+    }
+
+    private String generateOrderNo() {
+        String timestamp = LocalDateTime.now().format(ORDER_NO_FMT);
+        int random = ThreadLocalRandom.current().nextInt(1000, 9999);
+        return "ORD" + timestamp + random;
+    }
+
+    private String generateExecutionNo() {
+        String timestamp = LocalDateTime.now().format(ORDER_NO_FMT);
+        int random = ThreadLocalRandom.current().nextInt(1000, 9999);
+        return "EXE" + timestamp + random;
+    }
+
+    private void validateOwnership(Long userId, Order order) {
+        if (!order.getAccount().getUser().getUserId().equals(userId)) {
+            throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/sollite/order/service/OrderWaitingSubscriptionManager.java
+++ b/src/main/java/com/sollite/order/service/OrderWaitingSubscriptionManager.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -182,7 +183,7 @@ public class OrderWaitingSubscriptionManager {
      * 국내: US3 (체결), 해외: GSC (체결)
      */
     private String resolveTrCd(String marketType) {
-        if ("FOREIGN".equalsIgnoreCase(marketType)) {
+        if (List.of("NASDAQ", "NYSE", "AMEX").contains(marketType)) {
             return "GSC";
         }
         return "US3";

--- a/src/main/java/com/sollite/order/service/OrderWaitingSubscriptionManager.java
+++ b/src/main/java/com/sollite/order/service/OrderWaitingSubscriptionManager.java
@@ -1,0 +1,190 @@
+package com.sollite.order.service;
+
+import com.sollite.order.domain.entity.Order;
+import com.sollite.order.domain.repository.OrderRepository;
+import com.sollite.websocket.service.LsBrokerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * PENDING LIMIT 주문이 존재하는 종목의 LS 실시간 구독을 유지한다.
+ * <p>
+ * 프론트 STOMP 구독과 독립적으로 동작하여,
+ * 사용자가 화면을 닫아도 LIMIT 주문 체결이 가능하도록 보장한다.
+ * <p>
+ * subscriberCount는 직접 건드리지 않고 LsBrokerService.subscribe()/unsubscribe()만 사용한다.
+ * <p>
+ * hold()는 orderToKey에 즉시 등록하되, 실제 LS subscribe는 트랜잭션 커밋 후 실행한다.
+ * release()는 orderToKey에서 즉시 제거하여, hold의 afterCommit에서 구독을 스킵하도록 한다.
+ * 이로써 같은 트랜잭션 내에서 hold→즉시체결→release가 일어나도 구독 누수가 발생하지 않는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderWaitingSubscriptionManager {
+
+    private final LsBrokerService lsBrokerService;
+    private final OrderRepository orderRepository;
+
+    /**
+     * orderId → "trCd:stockCode" 매핑
+     * hold() 시 즉시 등록, release() 시 즉시 제거.
+     * afterCommit에서 이 맵을 확인하여 실제 subscribe 여부를 결정한다.
+     */
+    private final Map<Long, String> orderToKey = new ConcurrentHashMap<>();
+
+    /**
+     * 실제로 LS subscribe()가 호출된 주문 ID.
+     * release의 afterCommit에서 이 Set에 있는 경우에만 unsubscribe를 호출한다.
+     * (hold의 subscribe가 아직 실행되지 않았는데 unsubscribe를 호출하면 카운트가 꼬임)
+     */
+    private final Set<Long> subscribed = ConcurrentHashMap.newKeySet();
+
+    /**
+     * LIMIT 주문 접수 시 호출 — 트랜잭션 커밋 후 해당 종목의 LS 구독을 유지한다.
+     * orderToKey에 즉시 등록하여 release()가 찾을 수 있도록 한다.
+     * 멱등: 같은 orderId로 두 번 호출해도 카운트는 1번만 증가.
+     */
+    public void hold(Long orderId, String marketType, String stockCode) {
+        if (orderToKey.containsKey(orderId)) {
+            log.debug("[ORDER-SUB] 이미 hold 상태 — orderId={}", orderId);
+            return;
+        }
+
+        String trCd = resolveTrCd(marketType);
+        String key = trCd + ":" + stockCode;
+
+        // 즉시 맵에 등록 — release()가 같은 트랜잭션 내에서 호출돼도 찾을 수 있도록
+        orderToKey.put(orderId, key);
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    executeHold(orderId, trCd, stockCode, key);
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    if (status != STATUS_COMMITTED) {
+                        // 롤백 시 맵에서 정리
+                        orderToKey.remove(orderId);
+                    }
+                }
+            });
+        } else {
+            executeHold(orderId, trCd, stockCode, key);
+        }
+    }
+
+    /**
+     * 주문 체결/취소 시 호출 — 트랜잭션 커밋 후 해당 주문의 LS 구독을 해제한다.
+     * orderToKey에서 즉시 제거하여, hold의 afterCommit이 아직 안 돌았으면 subscribe를 스킵하게 한다.
+     * 멱등: 이미 release된 orderId에 대해 다시 호출해도 안전.
+     */
+    public void release(Long orderId) {
+        String key = orderToKey.remove(orderId);
+        if (key == null) {
+            log.debug("[ORDER-SUB] 이미 release 상태 — orderId={}", orderId);
+            return;
+        }
+
+        String[] parts = key.split(":", 2);
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    executeRelease(orderId, parts[0], parts[1]);
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    if (status != STATUS_COMMITTED) {
+                        // 롤백 시 다시 맵에 복원
+                        orderToKey.put(orderId, key);
+                    }
+                }
+            });
+        } else {
+            executeRelease(orderId, parts[0], parts[1]);
+        }
+    }
+
+    /**
+     * 커밋 후 실제 LS subscribe 실행.
+     * 커밋 전에 release()가 호출됐으면 orderToKey에서 이미 제거되어 스킵된다.
+     */
+    private void executeHold(Long orderId, String trCd, String stockCode, String key) {
+        if (!orderToKey.containsKey(orderId)) {
+            log.info("[ORDER-SUB] hold 스킵 (커밋 전 release됨) — orderId={}", orderId);
+            return;
+        }
+        lsBrokerService.subscribe(trCd, stockCode);
+        subscribed.add(orderId);
+        log.info("[ORDER-SUB] hold — orderId={}, trCd={}, stockCode={}", orderId, trCd, stockCode);
+    }
+
+    /**
+     * 커밋 후 실제 LS unsubscribe 실행.
+     * subscribe가 실제로 호출된 경우(subscribed Set에 존재)에만 unsubscribe를 호출한다.
+     * hold의 afterCommit에서 subscribe가 스킵됐으면 여기서도 스킵하여 카운트 오염을 방지한다.
+     */
+    private void executeRelease(Long orderId, String trCd, String stockCode) {
+        if (subscribed.remove(orderId)) {
+            lsBrokerService.unsubscribe(trCd, stockCode);
+            log.info("[ORDER-SUB] release — orderId={}, trCd={}, stockCode={}", orderId, trCd, stockCode);
+        } else {
+            log.debug("[ORDER-SUB] release 스킵 (구독 실행 전 release됨) — orderId={}", orderId);
+        }
+    }
+
+    /**
+     * 서버 기동 완료 후 DB에 남아있는 PENDING LIMIT 주문에 대해 LS 구독을 복구한다.
+     * ApplicationReadyEvent 사용 — DB/LS 연결 초기화 완료 후 실행.
+     */
+    @Transactional(readOnly = true)
+    @EventListener(ApplicationReadyEvent.class)
+    public void recoverOnStartup() {
+        var pendingOrders = orderRepository.findAllPendingLimitOrders();
+        if (pendingOrders.isEmpty()) {
+            log.info("[ORDER-SUB] 복구 대상 PENDING LIMIT 주문 없음");
+            return;
+        }
+
+        int recovered = 0;
+        for (Order order : pendingOrders) {
+            String trCd = resolveTrCd(order.getInstrument().getMarketType());
+            String stockCode = order.getInstrument().getStockCode();
+            String key = trCd + ":" + stockCode;
+
+            orderToKey.put(order.getOrderId(), key);
+            lsBrokerService.subscribe(trCd, stockCode);
+            subscribed.add(order.getOrderId());
+            log.info("[ORDER-SUB] hold (복구) — orderId={}, trCd={}, stockCode={}", order.getOrderId(), trCd, stockCode);
+            recovered++;
+        }
+        log.info("[ORDER-SUB] PENDING LIMIT 주문 구독 복구 완료 — {}건", recovered);
+    }
+
+    /**
+     * marketType → 체결 틱 TR 코드 변환
+     * 국내: US3 (체결), 해외: GSC (체결)
+     */
+    private String resolveTrCd(String marketType) {
+        if ("FOREIGN".equalsIgnoreCase(marketType)) {
+            return "GSC";
+        }
+        return "US3";
+    }
+}

--- a/src/main/java/com/sollite/websocket/service/LsBrokerService.java
+++ b/src/main/java/com/sollite/websocket/service/LsBrokerService.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.global.service.LsTokenService;
 import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.order.event.MarketTickEvent;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ public class LsBrokerService {
     private final SimpMessagingTemplate messagingTemplate;
     private final StringRedisTemplate redisTemplate;
     private final InstrumentRepository instrumentRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     private static final String INDEX_SNAPSHOT_PREFIX = "index:snapshot:";
     private static final Duration INDEX_SNAPSHOT_TTL = Duration.ofHours(48);
@@ -288,10 +291,39 @@ public class LsBrokerService {
                 redisTemplate.opsForValue().set(INDEX_SNAPSHOT_PREFIX + topic, bodyJson, INDEX_SNAPSHOT_TTL);
             }
 
+            // 체결 틱(US3/GSC)인 경우 주문 매칭용 내부 이벤트 발행
+            if ("US3".equals(trCd) || "GSC".equals(trCd)) {
+                java.math.BigDecimal tickPrice = extractTradePrice(trCd, body);
+                if (tickPrice != null) {
+                    applicationEventPublisher.publishEvent(
+                            new MarketTickEvent(symbol, tickPrice, trCd, java.time.Instant.now()));
+                }
+            }
+
         } catch (Exception e) {
             log.error("[LS-MSG] 처리 예외: {}, payload={}", e.getMessage(),
                     payload.length() > 200 ? payload.substring(0, 200) : payload, e);
         }
+    }
+
+    /**
+     * 체결가 추출 (주문 매칭용)
+     * US3(국내체결): price 필드
+     * GSC(해외체결): price 필드
+     */
+    private java.math.BigDecimal extractTradePrice(String trCd, JsonNode body) {
+        try {
+            String priceField = "price";
+            if (body.has(priceField)) {
+                String raw = body.get(priceField).asText().replace(",", "").trim();
+                if (!raw.isEmpty()) {
+                    return new java.math.BigDecimal(raw);
+                }
+            }
+        } catch (NumberFormatException e) {
+            log.warn("[LS-MSG] 체결가 파싱 실패: trCd={}, body={}", trCd, body);
+        }
+        return null;
     }
 
     /**

--- a/src/main/resources/db/migration/V5__alter_holdings_add_available_quantity.sql
+++ b/src/main/resources/db/migration/V5__alter_holdings_add_available_quantity.sql
@@ -1,0 +1,4 @@
+ALTER TABLE holdings
+ADD available_quantity NUMBER(12,0) DEFAULT 0 NOT NULL;
+
+COMMENT ON COLUMN holdings.available_quantity IS '매도 주문 가능 수량 (holding_quantity - PENDING/SUBMITTED 매도 주문 수량)';


### PR DESCRIPTION
## 연관된 이슈

없음

## 작업 내용

### order 도메인
- 주문 Enum 추가 (OrderSide, OrderKind, OrderStatus, OrderChannel)
- Order / OrderEvent / Execution Entity 및 Repository 추가
- 매수/매도 주문 접수·조회·취소·정정 API 구현
- 틱 기반 지정가 주문 매칭 및 체결 엔진 구현
- instrumentId → stockCode + marketType 구조 변경

### balance 도메인
- CashBalance / CashLedger / Holding / PositionLedger Entity, Enum, Repository 추가
- 예수금·매수가능금액·국내/해외 주식 잔고·포트폴리오 조회 API 구현

### account 도메인
- 계좌 개설/리셋 시 현금 잔고 초기화
- 계좌 폐쇄 조건 검증 추가

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

- 원장 설계 원칙(현금 잔고 음수 방지, 락 전략, 체결 흐름)이 올바르게 구현됐는지 중점적으로 봐주세요