### PR TITLE
feat(widget): 대시보드 위젯 레이아웃 저장/조회 API 구현

### DIFF
--- a/src/main/java/com/sollite/widget/controller/DashboardController.java
+++ b/src/main/java/com/sollite/widget/controller/DashboardController.java
@@ -1,0 +1,35 @@
+package com.sollite.widget.controller;
+
+import com.sollite.global.util.AuthUtil;
+import com.sollite.widget.dto.DashboardPageResponse;
+import com.sollite.widget.dto.DashboardSaveRequest;
+import com.sollite.widget.service.DashboardService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/dashboards")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/me")
+    public ResponseEntity<List<DashboardPageResponse>> getMyDashboards(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(dashboardService.getMyDashboards(userId));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<List<DashboardPageResponse>> saveMyDashboards(
+            Authentication authentication,
+            @Valid @RequestBody DashboardSaveRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(dashboardService.saveMyDashboards(userId, request));
+    }
+}

--- a/src/main/java/com/sollite/widget/domain/entity/Dashboard.java
+++ b/src/main/java/com/sollite/widget/domain/entity/Dashboard.java
@@ -1,0 +1,60 @@
+package com.sollite.widget.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "dashboards")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Dashboard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dashboard_id")
+    private Long dashboardId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "dashboard_name", length = 100)
+    private String dashboardName;
+
+    @Column(name = "page_order", nullable = false)
+    private Integer pageOrder;
+
+    @Column(name = "default_yn", nullable = false, columnDefinition = "CHAR(1)")
+    private String defaultYn = "N";
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "dashboard", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WidgetLayout> widgetLayouts = new ArrayList<>();
+
+    @Builder
+    public Dashboard(Long userId, String dashboardName, Integer pageOrder, String defaultYn) {
+        this.userId = userId;
+        this.dashboardName = dashboardName;
+        this.pageOrder = pageOrder;
+        this.defaultYn = defaultYn != null ? defaultYn : "N";
+    }
+
+    public void addWidgetLayout(WidgetLayout widgetLayout) {
+        this.widgetLayouts.add(widgetLayout);
+    }
+}

--- a/src/main/java/com/sollite/widget/domain/entity/WidgetLayout.java
+++ b/src/main/java/com/sollite/widget/domain/entity/WidgetLayout.java
@@ -41,7 +41,7 @@ public class WidgetLayout {
     private Integer height;
 
     @Lob
-    @Column(name = "config_json")
+    @Column(name = "config_json", columnDefinition = "CLOB")
     private String configJson;
 
     @CreationTimestamp

--- a/src/main/java/com/sollite/widget/domain/entity/WidgetLayout.java
+++ b/src/main/java/com/sollite/widget/domain/entity/WidgetLayout.java
@@ -1,0 +1,67 @@
+package com.sollite.widget.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "widget_layouts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WidgetLayout {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "widget_layout_id")
+    private Long widgetLayoutId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dashboard_id", nullable = false)
+    private Dashboard dashboard;
+
+    @Column(name = "widget_type", nullable = false, length = 50)
+    private String widgetType;
+
+    @Column(name = "position_x", nullable = false)
+    private Integer positionX;
+
+    @Column(name = "position_y", nullable = false)
+    private Integer positionY;
+
+    @Column(nullable = false)
+    private Integer width;
+
+    @Column(nullable = false)
+    private Integer height;
+
+    @Lob
+    @Column(name = "config_json")
+    private String configJson;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public WidgetLayout(Dashboard dashboard, String widgetType,
+                        Integer positionX, Integer positionY,
+                        Integer width, Integer height, String configJson) {
+        this.dashboard = dashboard;
+        this.widgetType = widgetType;
+        this.positionX = positionX;
+        this.positionY = positionY;
+        this.width = width;
+        this.height = height;
+        this.configJson = configJson;
+    }
+}

--- a/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
+++ b/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
@@ -2,6 +2,7 @@ package com.sollite.widget.domain.repository;
 
 import com.sollite.widget.domain.entity.Dashboard;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,5 +13,7 @@ public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
     @Query("SELECT DISTINCT d FROM Dashboard d LEFT JOIN FETCH d.widgetLayouts WHERE d.userId = :userId ORDER BY d.pageOrder")
     List<Dashboard> findAllByUserIdWithWidgets(@Param("userId") Long userId);
 
-    void deleteAllByUserId(Long userId);
+    @Modifying
+    @Query("DELETE FROM Dashboard d WHERE d.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
+++ b/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
@@ -12,7 +12,5 @@ public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
     @Query("SELECT DISTINCT d FROM Dashboard d LEFT JOIN FETCH d.widgetLayouts WHERE d.userId = :userId ORDER BY d.pageOrder")
     List<Dashboard> findAllByUserIdWithWidgets(@Param("userId") Long userId);
 
-    List<Dashboard> findAllByUserIdOrderByPageOrder(Long userId);
-
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
+++ b/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
@@ -1,0 +1,18 @@
+package com.sollite.widget.domain.repository;
+
+import com.sollite.widget.domain.entity.Dashboard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
+
+    @Query("SELECT DISTINCT d FROM Dashboard d LEFT JOIN FETCH d.widgetLayouts WHERE d.userId = :userId ORDER BY d.pageOrder")
+    List<Dashboard> findAllByUserIdWithWidgets(@Param("userId") Long userId);
+
+    List<Dashboard> findAllByUserIdOrderByPageOrder(Long userId);
+
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
+++ b/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
@@ -13,7 +13,7 @@ public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
     @Query("SELECT DISTINCT d FROM Dashboard d LEFT JOIN FETCH d.widgetLayouts WHERE d.userId = :userId ORDER BY d.pageOrder")
     List<Dashboard> findAllByUserIdWithWidgets(@Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Dashboard d WHERE d.userId = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/sollite/widget/dto/DashboardPageRequest.java
+++ b/src/main/java/com/sollite/widget/dto/DashboardPageRequest.java
@@ -1,0 +1,18 @@
+package com.sollite.widget.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record DashboardPageRequest(
+        String name,
+
+        @Min(value = 1, message = "pageOrder는 1 이상이어야 합니다")
+        int pageOrder,
+
+        @NotNull(message = "widgets는 필수입니다")
+        @Valid
+        List<WidgetLayoutRequest> widgets
+) {}

--- a/src/main/java/com/sollite/widget/dto/DashboardPageRequest.java
+++ b/src/main/java/com/sollite/widget/dto/DashboardPageRequest.java
@@ -3,11 +3,13 @@ package com.sollite.widget.dto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record DashboardPageRequest(
-        String name,
+        @Size(max = 100, message = "대시보드 이름은 100자 이하여야 합니다")
+        String name,  // nullable — 미입력 시 null 허용
 
         @Min(value = 1, message = "pageOrder는 1 이상이어야 합니다")
         int pageOrder,

--- a/src/main/java/com/sollite/widget/dto/DashboardPageResponse.java
+++ b/src/main/java/com/sollite/widget/dto/DashboardPageResponse.java
@@ -1,0 +1,24 @@
+package com.sollite.widget.dto;
+
+import com.sollite.widget.domain.entity.Dashboard;
+
+import java.util.List;
+
+public record DashboardPageResponse(
+        Long dashboardId,
+        String name,
+        int pageOrder,
+        List<WidgetLayoutResponse> widgets
+) {
+    public static DashboardPageResponse from(Dashboard d) {
+        List<WidgetLayoutResponse> widgets = d.getWidgetLayouts().stream()
+                .map(WidgetLayoutResponse::from)
+                .toList();
+        return new DashboardPageResponse(
+                d.getDashboardId(),
+                d.getDashboardName(),
+                d.getPageOrder(),
+                widgets
+        );
+    }
+}

--- a/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
+++ b/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
@@ -2,11 +2,13 @@ package com.sollite.widget.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record DashboardSaveRequest(
         @NotNull(message = "pages는 필수입니다")
+        @Size(min = 1, message = "최소 1개 이상의 페이지가 필요합니다")
         @Valid
         List<DashboardPageRequest> pages
 ) {}

--- a/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
+++ b/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
@@ -1,0 +1,12 @@
+package com.sollite.widget.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record DashboardSaveRequest(
+        @NotNull(message = "pages는 필수입니다")
+        @Valid
+        List<DashboardPageRequest> pages
+) {}

--- a/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
+++ b/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public record DashboardSaveRequest(
         @NotNull(message = "pages는 필수입니다")
-        @Size(min = 1, message = "최소 1개 이상의 페이지가 필요합니다")
+        @Size(min = 1, max = 5, message = "페이지는 1개 이상 5개 이하여야 합니다")
         @Valid
         List<DashboardPageRequest> pages
 ) {}

--- a/src/main/java/com/sollite/widget/dto/WidgetLayoutRequest.java
+++ b/src/main/java/com/sollite/widget/dto/WidgetLayoutRequest.java
@@ -8,10 +8,10 @@ public record WidgetLayoutRequest(
         String widgetType,
 
         @Min(value = 1, message = "positionX는 1 이상이어야 합니다")
-        int positionX,
+        int positionX,  // 1-based (CSS grid 좌표 체계와 동일)
 
         @Min(value = 1, message = "positionY는 1 이상이어야 합니다")
-        int positionY,
+        int positionY,  // 1-based (CSS grid 좌표 체계와 동일)
 
         @Min(value = 1, message = "width는 1 이상이어야 합니다")
         int width,

--- a/src/main/java/com/sollite/widget/dto/WidgetLayoutRequest.java
+++ b/src/main/java/com/sollite/widget/dto/WidgetLayoutRequest.java
@@ -1,0 +1,23 @@
+package com.sollite.widget.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record WidgetLayoutRequest(
+        @NotBlank(message = "위젯 타입은 필수입니다")
+        String widgetType,
+
+        @Min(value = 1, message = "positionX는 1 이상이어야 합니다")
+        int positionX,
+
+        @Min(value = 1, message = "positionY는 1 이상이어야 합니다")
+        int positionY,
+
+        @Min(value = 1, message = "width는 1 이상이어야 합니다")
+        int width,
+
+        @Min(value = 1, message = "height는 1 이상이어야 합니다")
+        int height,
+
+        String configJson
+) {}

--- a/src/main/java/com/sollite/widget/dto/WidgetLayoutResponse.java
+++ b/src/main/java/com/sollite/widget/dto/WidgetLayoutResponse.java
@@ -1,0 +1,25 @@
+package com.sollite.widget.dto;
+
+import com.sollite.widget.domain.entity.WidgetLayout;
+
+public record WidgetLayoutResponse(
+        Long widgetLayoutId,
+        String widgetType,
+        int positionX,
+        int positionY,
+        int width,
+        int height,
+        String configJson
+) {
+    public static WidgetLayoutResponse from(WidgetLayout w) {
+        return new WidgetLayoutResponse(
+                w.getWidgetLayoutId(),
+                w.getWidgetType(),
+                w.getPositionX(),
+                w.getPositionY(),
+                w.getWidth(),
+                w.getHeight(),
+                w.getConfigJson()
+        );
+    }
+}

--- a/src/main/java/com/sollite/widget/exception/WidgetErrorCode.java
+++ b/src/main/java/com/sollite/widget/exception/WidgetErrorCode.java
@@ -1,0 +1,15 @@
+package com.sollite.widget.exception;
+
+import com.sollite.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WidgetErrorCode implements ErrorCode {
+
+    DUPLICATE_PAGE_ORDER(400, "pageOrder 중복 값이 존재합니다");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/sollite/widget/service/DashboardService.java
+++ b/src/main/java/com/sollite/widget/service/DashboardService.java
@@ -1,0 +1,61 @@
+package com.sollite.widget.service;
+
+import com.sollite.widget.domain.entity.Dashboard;
+import com.sollite.widget.domain.entity.WidgetLayout;
+import com.sollite.widget.domain.repository.DashboardRepository;
+import com.sollite.widget.dto.DashboardPageResponse;
+import com.sollite.widget.dto.DashboardSaveRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+
+    private final DashboardRepository dashboardRepository;
+
+    @Transactional(readOnly = true)
+    public List<DashboardPageResponse> getMyDashboards(Long userId) {
+        return dashboardRepository.findAllByUserIdWithWidgets(userId).stream()
+                .map(DashboardPageResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public List<DashboardPageResponse> saveMyDashboards(Long userId, DashboardSaveRequest request) {
+        List<Dashboard> existing = dashboardRepository.findAllByUserIdOrderByPageOrder(userId);
+        dashboardRepository.deleteAll(existing);
+        dashboardRepository.flush();
+
+        List<Dashboard> toSave = request.pages().stream()
+                .map(page -> {
+                    Dashboard dashboard = Dashboard.builder()
+                            .userId(userId)
+                            .dashboardName(page.name())
+                            .pageOrder(page.pageOrder())
+                            .defaultYn(page.pageOrder() == 1 ? "Y" : "N")
+                            .build();
+
+                    page.widgets().forEach(w -> dashboard.addWidgetLayout(
+                            WidgetLayout.builder()
+                                    .dashboard(dashboard)
+                                    .widgetType(w.widgetType())
+                                    .positionX(w.positionX())
+                                    .positionY(w.positionY())
+                                    .width(w.width())
+                                    .height(w.height())
+                                    .configJson(w.configJson())
+                                    .build()
+                    ));
+                    return dashboard;
+                })
+                .toList();
+
+        return dashboardRepository.saveAll(toSave).stream()
+                .map(DashboardPageResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/sollite/widget/service/DashboardService.java
+++ b/src/main/java/com/sollite/widget/service/DashboardService.java
@@ -1,16 +1,19 @@
 package com.sollite.widget.service;
 
+import com.sollite.global.exception.BusinessException;
 import com.sollite.widget.domain.entity.Dashboard;
 import com.sollite.widget.domain.entity.WidgetLayout;
 import com.sollite.widget.domain.repository.DashboardRepository;
+import com.sollite.widget.dto.DashboardPageRequest;
 import com.sollite.widget.dto.DashboardPageResponse;
 import com.sollite.widget.dto.DashboardSaveRequest;
+import com.sollite.widget.exception.WidgetErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -27,18 +30,26 @@ public class DashboardService {
 
     @Transactional
     public List<DashboardPageResponse> saveMyDashboards(Long userId, DashboardSaveRequest request) {
-        dashboardRepository.deleteAllByUserId(userId);
-        dashboardRepository.flush();
+        List<DashboardPageRequest> pages = request.pages();
 
-        AtomicInteger index = new AtomicInteger(0);
-        List<Dashboard> toSave = request.pages().stream()
-                .map(page -> {
-                    boolean isFirst = index.getAndIncrement() == 0;
+        long distinctCount = pages.stream()
+                .mapToInt(DashboardPageRequest::pageOrder)
+                .distinct()
+                .count();
+        if (distinctCount != pages.size()) {
+            throw new BusinessException(WidgetErrorCode.DUPLICATE_PAGE_ORDER);
+        }
+
+        dashboardRepository.deleteAllByUserId(userId);
+
+        List<Dashboard> toSave = IntStream.range(0, pages.size())
+                .mapToObj(i -> {
+                    DashboardPageRequest page = pages.get(i);
                     Dashboard dashboard = Dashboard.builder()
                             .userId(userId)
                             .dashboardName(page.name())
                             .pageOrder(page.pageOrder())
-                            .defaultYn(isFirst ? "Y" : "N")
+                            .defaultYn(i == 0 ? "Y" : "N")
                             .build();
 
                     page.widgets().forEach(w -> dashboard.addWidgetLayout(

--- a/src/main/java/com/sollite/widget/service/DashboardService.java
+++ b/src/main/java/com/sollite/widget/service/DashboardService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Service
 @RequiredArgsConstructor
@@ -26,17 +27,18 @@ public class DashboardService {
 
     @Transactional
     public List<DashboardPageResponse> saveMyDashboards(Long userId, DashboardSaveRequest request) {
-        List<Dashboard> existing = dashboardRepository.findAllByUserIdOrderByPageOrder(userId);
-        dashboardRepository.deleteAll(existing);
+        dashboardRepository.deleteAllByUserId(userId);
         dashboardRepository.flush();
 
+        AtomicInteger index = new AtomicInteger(0);
         List<Dashboard> toSave = request.pages().stream()
                 .map(page -> {
+                    boolean isFirst = index.getAndIncrement() == 0;
                     Dashboard dashboard = Dashboard.builder()
                             .userId(userId)
                             .dashboardName(page.name())
                             .pageOrder(page.pageOrder())
-                            .defaultYn(page.pageOrder() == 1 ? "Y" : "N")
+                            .defaultYn(isFirst ? "Y" : "N")
                             .build();
 
                     page.widgets().forEach(w -> dashboard.addWidgetLayout(

--- a/src/main/resources/db/migration/V6__alter_widget_layouts_add_cascade_delete.sql
+++ b/src/main/resources/db/migration/V6__alter_widget_layouts_add_cascade_delete.sql
@@ -1,0 +1,5 @@
+-- widget_layouts FK에 ON DELETE CASCADE 추가
+-- DashboardRepository @Modifying @Query 사용 시 JPA cascade 우회 → DB CASCADE 필요
+ALTER TABLE widget_layouts DROP CONSTRAINT fk_wlayouts_dashboard;
+ALTER TABLE widget_layouts ADD CONSTRAINT fk_wlayouts_dashboard
+    FOREIGN KEY (dashboard_id) REFERENCES dashboards (dashboard_id) ON DELETE CASCADE;


### PR DESCRIPTION
## 작업 내용

- `Dashboard`, `WidgetLayout` JPA Entity 구현
- `DashboardRepository` — fetch join으로 N+1 방지
- `DashboardService` — 조회(readOnly) + 전체 교체 저장(upsert)
- `DashboardController` — `GET/PUT /api/dashboards/me`
- Request/Response DTO (record 타입, Bean Validation 적용)

## API

| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | /api/dashboards/me | 내 전체 페이지 + 위젯 레이아웃 조회 |
| PUT | /api/dashboards/me | 전체 레이아웃 일괄 저장 (delete-all + reinsert) |

## 설계 결정

- 신규 사용자는 빈 배열 반환 (프론트엔드가 INITIAL 레이아웃 유지)
- `variantId`는 `config_json`에 포함하여 저장
- Flyway 마이그레이션 불필요 (V1에 테이블 이미 존재)

## 확인 방법

1. 로그인 후 `GET /api/dashboards/me` → 빈 배열 반환 확인
2. `PUT /api/dashboards/me` 로 레이아웃 저장 → 저장된 ID 포함 응답 확인
3. 재조회 시 저장된 레이아웃 반환 확인

close #38