### PR TITLE
feat(watchlist): 관심종목 조회/추가/삭제/순서 변경 API 구현

### DIFF
--- a/src/main/java/com/sollite/global/config/CacheConfig.java
+++ b/src/main/java/com/sollite/global/config/CacheConfig.java
@@ -50,6 +50,7 @@ public class CacheConfig {
                 Map.entry("market:finance",      base.entryTtl(Duration.ofHours(1))),
                 Map.entry("market:opinion",      base.entryTtl(Duration.ofHours(1))),
                 Map.entry("market:investor",     base.entryTtl(Duration.ofHours(1))),
+                Map.entry("market:info",         base.entryTtl(Duration.ofHours(24))),
                 // 국내주식 순위
                 Map.entry("market:ranking",          base.entryTtl(Duration.ofSeconds(30))),
                 // 해외주식

--- a/src/main/java/com/sollite/market/controller/MarketController.java
+++ b/src/main/java/com/sollite/market/controller/MarketController.java
@@ -79,4 +79,8 @@ public class MarketController {
         return ResponseEntity.ok(marketService.getRanking(type, market));
     }
 
+    @GetMapping("/stocks/{stockCode}/info")
+    public ResponseEntity<StockInfoResponse> getStockInfo(@PathVariable String stockCode) {
+        return ResponseEntity.ok(marketService.getStockInfo(stockCode));
+    }
 }

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
@@ -52,4 +52,13 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
     Optional<Instrument> findByStockCodeAndMarketTypeIn(
             @Param("stockCode") String stockCode,
             @Param("marketTypes") List<String> marketTypes);
+
+    @Query("""
+            SELECT i FROM Instrument i
+            WHERE i.activeYn = 'Y'
+              AND UPPER(i.stockCode) = UPPER(:stockCode)
+              AND i.exchangeCode IS NOT NULL
+            ORDER BY i.instrumentId ASC
+            """)
+    List<Instrument> findActiveByStockCode(@Param("stockCode") String stockCode);
 }

--- a/src/main/java/com/sollite/market/dto/LsCurrentPriceRes.java
+++ b/src/main/java/com/sollite/market/dto/LsCurrentPriceRes.java
@@ -9,6 +9,7 @@ public record LsCurrentPriceRes(
             int price,       // 현재가
             String diff,     // 등락율 (문자열)
             int change,      // 전일대비 변동금액
-            long volume      // 누적거래량
+            long volume,     // 누적거래량
+            String listdate  // 상장일 (yyyyMMdd)
     ) {}
 }

--- a/src/main/java/com/sollite/market/dto/LsT3320Res.java
+++ b/src/main/java/com/sollite/market/dto/LsT3320Res.java
@@ -1,0 +1,17 @@
+package com.sollite.market.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsT3320Res(
+        String rsp_cd,
+        String rsp_msg,
+        LsT3320OutBlock t3320OutBlock
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record LsT3320OutBlock(
+            String company,     // 한글 기업명
+            String upgubunnm,   // 업종 구분명
+            String marketnm     // 시장 구분명
+    ) {}
+}

--- a/src/main/java/com/sollite/market/dto/StockInfoResponse.java
+++ b/src/main/java/com/sollite/market/dto/StockInfoResponse.java
@@ -1,0 +1,9 @@
+package com.sollite.market.dto;
+
+public record StockInfoResponse(
+        String stockCode,
+        String companyName,
+        String sector,
+        String marketName,
+        String listDate
+) {}

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -731,4 +731,97 @@ class LsMarketServiceImpl implements MarketService {
             throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
         }
     }
+
+    @Override
+    @Cacheable(cacheNames = "market:info", key = "#stockCode")
+    public StockInfoResponse getStockInfo(String stockCode) {
+        return getStockInfo(stockCode, false);
+    }
+
+    private StockInfoResponse getStockInfo(String stockCode, boolean isRetry) {
+        String token = tokenService.getAccessToken();
+        try {
+            // t1102 - 상장일 조회
+            record T1102ReqBody(String shcode) {}
+            record T1102Req(T1102ReqBody t1102InBlock) {}
+
+            String raw1102 = lsWebClient.post()
+                    .uri("/stock/market-data")
+                    .header("authorization", "Bearer " + token)
+                    .header("content-type", "application/json; charset=utf-8")
+                    .header("tr_cd", "t1102")
+                    .header("tr_cont", "N")
+                    .header("mac_address", DUMMY_MAC)
+                    .bodyValue(new T1102Req(new T1102ReqBody(stockCode)))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.debug("LS t1102 raw (info): {}", raw1102);
+            LsCurrentPriceRes res1102 = objectMapper.readValue(raw1102, LsCurrentPriceRes.class);
+            if (res1102 == null || !"00000".equals(res1102.rsp_cd())) {
+                throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+            }
+
+            // t3320 - 기업명/업종 조회
+            record T3320ReqBody(String gicode) {}
+            record T3320Req(T3320ReqBody t3320InBlock) {}
+
+            String raw3320 = lsWebClient.post()
+                    .uri("/stock/investinfo")
+                    .header("authorization", "Bearer " + token)
+                    .header("content-type", "application/json; charset=utf-8")
+                    .header("tr_cd", "t3320")
+                    .header("tr_cont", "N")
+                    .header("mac_address", DUMMY_MAC)
+                    .bodyValue(new T3320Req(new T3320ReqBody(stockCode)))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.debug("LS t3320 raw: {}", raw3320);
+            LsT3320Res res3320 = objectMapper.readValue(raw3320, LsT3320Res.class);
+            if (res3320 == null || !"00000".equals(res3320.rsp_cd())) {
+                throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+            }
+
+            // 상장일 포맷 변환: yyyyMMdd → yyyy-MM-dd
+            String listdate = res1102.t1102OutBlock().listdate();
+            String formattedListDate = (listdate != null && listdate.length() == 8)
+                    ? listdate.substring(0, 4) + "-" + listdate.substring(4, 6) + "-" + listdate.substring(6, 8)
+                    : listdate;
+
+            LsT3320Res.LsT3320OutBlock info = res3320.t3320OutBlock();
+            return new StockInfoResponse(
+                    stockCode,
+                    info.company(),
+                    info.upgubunnm(),
+                    resolveMarketName(info.marketnm()),
+                    formattedListDate
+            );
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            if (!isRetry && e.getStatusCode().value() == 401) {
+                tokenService.invalidateToken();
+                return getStockInfo(stockCode, true);
+            }
+            log.error("LS증권 API 호출 실패: {}", e.getResponseBodyAsString());
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        } catch (Exception e) {
+            log.error("기업 정보 조회 실패: stockCode={}, error={}", stockCode, e.getMessage());
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        }
+    }
+
+    private String resolveMarketName(String marketnm) {
+        if (marketnm == null) return "";
+        return switch (marketnm.trim()) {
+            case "거래소" -> "KOSPI";
+            case "코스닥" -> "KOSDAQ";
+            case "코넥스" -> "KONEX";
+            default -> marketnm;
+        };
+    }
 }

--- a/src/main/java/com/sollite/market/service/MarketService.java
+++ b/src/main/java/com/sollite/market/service/MarketService.java
@@ -9,6 +9,7 @@ import com.sollite.market.dto.FinanceResponse;
 import com.sollite.market.dto.OpinionResponse;
 import com.sollite.market.dto.InvestorResponse;
 import com.sollite.market.dto.OrderbookResponse;
+import com.sollite.market.dto.StockInfoResponse;
 import com.sollite.market.dto.StockRankingItem;
 
 import java.time.LocalDate;
@@ -24,4 +25,5 @@ public interface MarketService {
     InvestorResponse getInvestor(String stockCode);
     OrderbookResponse getOrderbook(String stockCode);
     List<StockRankingItem> getRanking(String type, String market);
+    StockInfoResponse getStockInfo(String stockCode);
 }

--- a/src/main/java/com/sollite/watchlist/controller/WatchlistController.java
+++ b/src/main/java/com/sollite/watchlist/controller/WatchlistController.java
@@ -1,0 +1,55 @@
+package com.sollite.watchlist.controller;
+
+import com.sollite.global.util.AuthUtil;
+import com.sollite.watchlist.dto.WatchlistAddRequest;
+import com.sollite.watchlist.dto.WatchlistItemResponse;
+import com.sollite.watchlist.dto.WatchlistOrderRequest;
+import com.sollite.watchlist.service.WatchlistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/watchlist")
+@RequiredArgsConstructor
+public class WatchlistController {
+
+    private final WatchlistService watchlistService;
+
+    @GetMapping
+    public ResponseEntity<List<WatchlistItemResponse>> getWatchlist(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(watchlistService.getWatchlist(userId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> addToWatchlist(
+            Authentication authentication,
+            @RequestBody WatchlistAddRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        watchlistService.addToWatchlist(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{stockCode}")
+    public ResponseEntity<Void> removeFromWatchlist(
+            Authentication authentication,
+            @PathVariable String stockCode) {
+        Long userId = AuthUtil.getUserId(authentication);
+        watchlistService.removeFromWatchlist(userId, stockCode);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/order")
+    public ResponseEntity<Void> updateOrder(
+            Authentication authentication,
+            @RequestBody WatchlistOrderRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        watchlistService.updateOrder(userId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/sollite/watchlist/controller/WatchlistController.java
+++ b/src/main/java/com/sollite/watchlist/controller/WatchlistController.java
@@ -5,6 +5,7 @@ import com.sollite.watchlist.dto.WatchlistAddRequest;
 import com.sollite.watchlist.dto.WatchlistItemResponse;
 import com.sollite.watchlist.dto.WatchlistOrderRequest;
 import com.sollite.watchlist.service.WatchlistService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,7 @@ public class WatchlistController {
     @PostMapping
     public ResponseEntity<Void> addToWatchlist(
             Authentication authentication,
-            @RequestBody WatchlistAddRequest request) {
+            @Valid @RequestBody WatchlistAddRequest request) {
         Long userId = AuthUtil.getUserId(authentication);
         watchlistService.addToWatchlist(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -47,7 +48,7 @@ public class WatchlistController {
     @PatchMapping("/order")
     public ResponseEntity<Void> updateOrder(
             Authentication authentication,
-            @RequestBody WatchlistOrderRequest request) {
+            @Valid @RequestBody WatchlistOrderRequest request) {
         Long userId = AuthUtil.getUserId(authentication);
         watchlistService.updateOrder(userId, request);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/sollite/watchlist/domain/entity/WatchlistItem.java
+++ b/src/main/java/com/sollite/watchlist/domain/entity/WatchlistItem.java
@@ -1,0 +1,44 @@
+package com.sollite.watchlist.domain.entity;
+
+import com.sollite.market.domain.entity.Instrument;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "watchlist_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WatchlistItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "watchlist_item_id")
+    private Long watchlistItemId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instrument_id", nullable = false)
+    private Instrument instrument;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static WatchlistItem create(Long userId, Instrument instrument, int displayOrder) {
+        WatchlistItem item = new WatchlistItem();
+        item.userId = userId;
+        item.instrument = instrument;
+        item.displayOrder = displayOrder;
+        return item;
+    }
+}

--- a/src/main/java/com/sollite/watchlist/domain/repository/WatchlistItemRepository.java
+++ b/src/main/java/com/sollite/watchlist/domain/repository/WatchlistItemRepository.java
@@ -20,11 +20,13 @@ public interface WatchlistItemRepository extends JpaRepository<WatchlistItem, Lo
     @Query("SELECT COALESCE(MAX(wi.displayOrder), 0) FROM WatchlistItem wi WHERE wi.userId = :userId")
     int findMaxDisplayOrderByUserId(@Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM WatchlistItem wi WHERE wi.userId = :userId AND wi.instrument.stockCode = :stockCode")
     int deleteByUserIdAndStockCode(@Param("userId") Long userId, @Param("stockCode") String stockCode);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE WatchlistItem wi SET wi.displayOrder = :displayOrder WHERE wi.userId = :userId AND wi.instrument.stockCode = :stockCode")
     void updateDisplayOrder(@Param("userId") Long userId, @Param("stockCode") String stockCode, @Param("displayOrder") int displayOrder);
+
+    long countByUserId(Long userId);
 }

--- a/src/main/java/com/sollite/watchlist/domain/repository/WatchlistItemRepository.java
+++ b/src/main/java/com/sollite/watchlist/domain/repository/WatchlistItemRepository.java
@@ -1,0 +1,30 @@
+package com.sollite.watchlist.domain.repository;
+
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.watchlist.domain.entity.WatchlistItem;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface WatchlistItemRepository extends JpaRepository<WatchlistItem, Long> {
+
+    @EntityGraph(attributePaths = {"instrument"})
+    List<WatchlistItem> findByUserIdOrderByDisplayOrderAsc(Long userId);
+
+    boolean existsByUserIdAndInstrument(Long userId, Instrument instrument);
+
+    @Query("SELECT COALESCE(MAX(wi.displayOrder), 0) FROM WatchlistItem wi WHERE wi.userId = :userId")
+    int findMaxDisplayOrderByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("DELETE FROM WatchlistItem wi WHERE wi.userId = :userId AND wi.instrument.stockCode = :stockCode")
+    int deleteByUserIdAndStockCode(@Param("userId") Long userId, @Param("stockCode") String stockCode);
+
+    @Modifying
+    @Query("UPDATE WatchlistItem wi SET wi.displayOrder = :displayOrder WHERE wi.userId = :userId AND wi.instrument.stockCode = :stockCode")
+    void updateDisplayOrder(@Param("userId") Long userId, @Param("stockCode") String stockCode, @Param("displayOrder") int displayOrder);
+}

--- a/src/main/java/com/sollite/watchlist/dto/WatchlistAddRequest.java
+++ b/src/main/java/com/sollite/watchlist/dto/WatchlistAddRequest.java
@@ -1,4 +1,6 @@
 package com.sollite.watchlist.dto;
 
-public record WatchlistAddRequest(String stockCode) {
+import jakarta.validation.constraints.NotBlank;
+
+public record WatchlistAddRequest(@NotBlank String stockCode) {
 }

--- a/src/main/java/com/sollite/watchlist/dto/WatchlistAddRequest.java
+++ b/src/main/java/com/sollite/watchlist/dto/WatchlistAddRequest.java
@@ -1,0 +1,4 @@
+package com.sollite.watchlist.dto;
+
+public record WatchlistAddRequest(String stockCode) {
+}

--- a/src/main/java/com/sollite/watchlist/dto/WatchlistItemResponse.java
+++ b/src/main/java/com/sollite/watchlist/dto/WatchlistItemResponse.java
@@ -1,0 +1,11 @@
+package com.sollite.watchlist.dto;
+
+public record WatchlistItemResponse(
+        String stockCode,
+        String stockName,
+        int currentPrice,
+        double changeRate,
+        int changeAmount,
+        long volume
+) {
+}

--- a/src/main/java/com/sollite/watchlist/dto/WatchlistOrderRequest.java
+++ b/src/main/java/com/sollite/watchlist/dto/WatchlistOrderRequest.java
@@ -1,6 +1,9 @@
 package com.sollite.watchlist.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.util.List;
 
-public record WatchlistOrderRequest(List<String> stockCodes) {
+public record WatchlistOrderRequest(@NotNull @Size(min = 1) List<String> stockCodes) {
 }

--- a/src/main/java/com/sollite/watchlist/dto/WatchlistOrderRequest.java
+++ b/src/main/java/com/sollite/watchlist/dto/WatchlistOrderRequest.java
@@ -1,0 +1,6 @@
+package com.sollite.watchlist.dto;
+
+import java.util.List;
+
+public record WatchlistOrderRequest(List<String> stockCodes) {
+}

--- a/src/main/java/com/sollite/watchlist/exception/WatchlistErrorCode.java
+++ b/src/main/java/com/sollite/watchlist/exception/WatchlistErrorCode.java
@@ -1,0 +1,16 @@
+package com.sollite.watchlist.exception;
+
+import com.sollite.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WatchlistErrorCode implements ErrorCode {
+
+    INSTRUMENT_NOT_FOUND(404, "존재하지 않는 종목입니다"),
+    ALREADY_IN_WATCHLIST(409, "이미 관심 종목에 추가된 종목입니다");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/sollite/watchlist/exception/WatchlistErrorCode.java
+++ b/src/main/java/com/sollite/watchlist/exception/WatchlistErrorCode.java
@@ -9,7 +9,10 @@ import lombok.RequiredArgsConstructor;
 public enum WatchlistErrorCode implements ErrorCode {
 
     INSTRUMENT_NOT_FOUND(404, "존재하지 않는 종목입니다"),
-    ALREADY_IN_WATCHLIST(409, "이미 관심 종목에 추가된 종목입니다");
+    WATCHLIST_ITEM_NOT_FOUND(404, "관심 종목에 등록되지 않은 종목입니다"),
+    WATCHLIST_LIMIT_EXCEEDED(400, "관심 종목은 최대 50개까지 등록할 수 있습니다"),
+    ALREADY_IN_WATCHLIST(409, "이미 관심 종목에 추가된 종목입니다"),
+    WATCHLIST_SIZE_MISMATCH(400, "전달된 종목 수가 현재 관심 종목 수와 일치하지 않습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/sollite/watchlist/service/WatchlistService.java
@@ -1,0 +1,78 @@
+package com.sollite.watchlist.service;
+
+import com.sollite.global.exception.BusinessException;
+import com.sollite.market.domain.entity.Instrument;
+import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.market.dto.CurrentPriceResponse;
+import com.sollite.market.service.MarketService;
+import com.sollite.watchlist.domain.entity.WatchlistItem;
+import com.sollite.watchlist.domain.repository.WatchlistItemRepository;
+import com.sollite.watchlist.dto.WatchlistAddRequest;
+import com.sollite.watchlist.dto.WatchlistItemResponse;
+import com.sollite.watchlist.dto.WatchlistOrderRequest;
+import com.sollite.watchlist.exception.WatchlistErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WatchlistService {
+
+    private final WatchlistItemRepository watchlistItemRepository;
+    private final InstrumentRepository instrumentRepository;
+    private final MarketService marketService;
+
+    public List<WatchlistItemResponse> getWatchlist(Long userId) {
+        return watchlistItemRepository.findByUserIdOrderByDisplayOrderAsc(userId)
+                .stream()
+                .map(item -> {
+                    Instrument inst = item.getInstrument();
+                    CurrentPriceResponse price = marketService.getCurrentPrice(inst.getStockCode());
+                    return new WatchlistItemResponse(
+                            inst.getStockCode(),
+                            inst.getStockName(),
+                            price.currentPrice(),
+                            price.changeRate(),
+                            price.changeAmount(),
+                            price.volume()
+                    );
+                })
+                .toList();
+    }
+
+    @Transactional
+    public void addToWatchlist(Long userId, WatchlistAddRequest request) {
+        Instrument instrument = instrumentRepository
+                .findActiveByStockCode(request.stockCode())
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(WatchlistErrorCode.INSTRUMENT_NOT_FOUND));
+
+        if (watchlistItemRepository.existsByUserIdAndInstrument(userId, instrument)) {
+            throw new BusinessException(WatchlistErrorCode.ALREADY_IN_WATCHLIST);
+        }
+
+        int nextOrder = watchlistItemRepository.findMaxDisplayOrderByUserId(userId) + 1;
+        watchlistItemRepository.save(WatchlistItem.create(userId, instrument, nextOrder));
+    }
+
+    @Transactional
+    public void removeFromWatchlist(Long userId, String stockCode) {
+        int deleted = watchlistItemRepository.deleteByUserIdAndStockCode(userId, stockCode);
+        if (deleted == 0) {
+            throw new BusinessException(WatchlistErrorCode.INSTRUMENT_NOT_FOUND);
+        }
+    }
+
+    @Transactional
+    public void updateOrder(Long userId, WatchlistOrderRequest request) {
+        List<String> stockCodes = request.stockCodes();
+        for (int i = 0; i < stockCodes.size(); i++) {
+            watchlistItemRepository.updateDisplayOrder(userId, stockCodes.get(i), i + 1);
+        }
+    }
+}

--- a/src/main/java/com/sollite/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/sollite/watchlist/service/WatchlistService.java
@@ -1,5 +1,6 @@
 package com.sollite.watchlist.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.market.domain.entity.Instrument;
 import com.sollite.market.domain.repository.InstrumentRepository;
@@ -11,27 +12,34 @@ import com.sollite.watchlist.dto.WatchlistAddRequest;
 import com.sollite.watchlist.dto.WatchlistItemResponse;
 import com.sollite.watchlist.dto.WatchlistOrderRequest;
 import com.sollite.watchlist.exception.WatchlistErrorCode;
+import com.sollite.websocket.service.LsBrokerService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class WatchlistService {
 
+    private static final int WATCHLIST_MAX_SIZE = 50;
+
     private final WatchlistItemRepository watchlistItemRepository;
     private final InstrumentRepository instrumentRepository;
     private final MarketService marketService;
+    private final LsBrokerService lsBrokerService;
+    private final ObjectMapper objectMapper;
 
     public List<WatchlistItemResponse> getWatchlist(Long userId) {
         return watchlistItemRepository.findByUserIdOrderByDisplayOrderAsc(userId)
                 .stream()
                 .map(item -> {
                     Instrument inst = item.getInstrument();
-                    CurrentPriceResponse price = marketService.getCurrentPrice(inst.getStockCode());
+                    CurrentPriceResponse price = resolveCurrentPrice(inst.getStockCode());
                     return new WatchlistItemResponse(
                             inst.getStockCode(),
                             inst.getStockName(),
@@ -42,6 +50,28 @@ public class WatchlistService {
                     );
                 })
                 .toList();
+    }
+
+    private CurrentPriceResponse resolveCurrentPrice(String stockCode) {
+        String topic = "/topic/stock/trade/" + stockCode;
+        String lastJson = lsBrokerService.getLastValue(topic);
+        if (lastJson != null) {
+            try {
+                var node = objectMapper.readTree(lastJson);
+                if (node.has("price")) {
+                    return new CurrentPriceResponse(
+                            stockCode,
+                            Integer.parseInt(node.get("price").asText().replace(",", "").trim()),
+                            node.has("diff") ? Double.parseDouble(node.get("diff").asText().replace(",", "").trim()) : 0.0,
+                            node.has("change") ? Integer.parseInt(node.get("change").asText().replace(",", "").trim()) : 0,
+                            node.has("volume") ? Long.parseLong(node.get("volume").asText().replace(",", "").trim()) : 0L
+                    );
+                }
+            } catch (Exception e) {
+                log.warn("[WATCHLIST] lastValue 파싱 실패 — topic={}, error={}", topic, e.getMessage());
+            }
+        }
+        return marketService.getCurrentPrice(stockCode);
     }
 
     @Transactional
@@ -56,6 +86,10 @@ public class WatchlistService {
             throw new BusinessException(WatchlistErrorCode.ALREADY_IN_WATCHLIST);
         }
 
+        if (watchlistItemRepository.countByUserId(userId) >= WATCHLIST_MAX_SIZE) {
+            throw new BusinessException(WatchlistErrorCode.WATCHLIST_LIMIT_EXCEEDED);
+        }
+
         int nextOrder = watchlistItemRepository.findMaxDisplayOrderByUserId(userId) + 1;
         watchlistItemRepository.save(WatchlistItem.create(userId, instrument, nextOrder));
     }
@@ -64,13 +98,17 @@ public class WatchlistService {
     public void removeFromWatchlist(Long userId, String stockCode) {
         int deleted = watchlistItemRepository.deleteByUserIdAndStockCode(userId, stockCode);
         if (deleted == 0) {
-            throw new BusinessException(WatchlistErrorCode.INSTRUMENT_NOT_FOUND);
+            throw new BusinessException(WatchlistErrorCode.WATCHLIST_ITEM_NOT_FOUND);
         }
     }
 
     @Transactional
     public void updateOrder(Long userId, WatchlistOrderRequest request) {
         List<String> stockCodes = request.stockCodes();
+        long currentCount = watchlistItemRepository.countByUserId(userId);
+        if (stockCodes.size() != currentCount) {
+            throw new BusinessException(WatchlistErrorCode.WATCHLIST_SIZE_MISMATCH);
+        }
         for (int i = 0; i < stockCodes.size(); i++) {
             watchlistItemRepository.updateDisplayOrder(userId, stockCodes.get(i), i + 1);
         }


### PR DESCRIPTION
## 연관된 이슈
> #이슈번호

## 작업 내용
관심종목 CRUD 및 순서 변경 API를 구현했습니다.

### 구현 API
- `GET /api/watchlist` — 관심종목 목록 조회 (현재가, 등락률, 거래량 포함)
- `POST /api/watchlist` — 관심종목 추가
- `DELETE /api/watchlist/{stockCode}` — 관심종목 삭제
- `PATCH /api/watchlist/order` — 관심종목 순서 변경

### 주요 구현 내용
- `WatchlistItem` 엔티티 — `WATCHLIST_ITEMS` 테이블과 매핑, `Instrument`와 ManyToOne 관계
- `@EntityGraph`로 Instrument fetch join 처리 → N+1 문제 방지
- 현재가 조회는 `MarketService.getCurrentPrice()` 재사용 (Redis 캐시 활용)
- `InstrumentRepository.findActiveByStockCode()` 추가 — `exchangeCode IS NOT NULL` 조건으로 유효한 종목만 조회

## 체크리스트
- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항
**POST 중복 추가 방지 전략에 대한 검토 요청**

현재 `existsByUserIdAndInstrument` 체크로 중복 추가를 방지하고 있습니다.
토글 버튼 특성상 동일 사용자가 동시에 요청을 보내는 경쟁 조건 발생 가능성이 낮아 `(user_id, instrument_id)` DB unique constraint는 미적용했습니다.

트래픽 증가 시 아래 방향으로 강화 가능합니다:
- `(user_id, instrument_id)` unique constraint 추가 + `DataIntegrityViolationException` 처리
- 비관적 락 (`@Lock(PESSIMISTIC_WRITE)`)
- 원자적 INSERT (`INSERT WHERE NOT EXISTS`)

**현재가 조회 순차 호출에 대한 검토 요청**

관심종목 N개에 대해 현재가를 순차 호출하고 있습니다.
`CompletableFuture` 병렬 호출로 응답 속도를 개선할 수 있으나, LS OpenAPI rate limit 위험 및 스레드 풀 고갈 가능성을 고려해 보류했습니다.
Redis 캐시(5s TTL)가 완충재 역할을 하므로 당장은 순차 호출로도 충분하다고 판단했습니다.
