### PR TITLE
feat(global): Swagger UI 액세스 토큰 자동 갱신

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,7 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
     persist-authorization: true
+    custom-js-url: /swagger-custom.js
   api-docs:
     path: /v3/api-docs
 

--- a/src/main/resources/static/swagger-custom.js
+++ b/src/main/resources/static/swagger-custom.js
@@ -1,0 +1,51 @@
+(function () {
+  function getTokenExpiry(token) {
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      return payload.exp * 1000;
+    } catch {
+      return null;
+    }
+  }
+
+  function isExpiredOrSoon(token) {
+    const exp = getTokenExpiry(token);
+    return exp === null || Date.now() > exp - 30_000;
+  }
+
+  async function refreshAccessToken() {
+    const res = await fetch('/api/auth/token/refresh', {
+      method: 'POST',
+      credentials: 'include', // httpOnly 쿠키 자동 전송
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.accessToken ?? null;
+  }
+
+  const timer = setInterval(() => {
+    if (!window.ui) return;
+    clearInterval(timer);
+
+    window.ui.getConfigs().requestInterceptor = async (request) => {
+      const auth = window.ui.getState().getIn(['auth', 'authorized', 'bearerAuth']);
+      if (!auth) return request;
+
+      const accessToken = auth.getIn(['value']);
+      if (!isExpiredOrSoon(accessToken)) return request;
+
+      console.log('[Swagger] Access token 만료 → 갱신 시도');
+      const newToken = await refreshAccessToken();
+
+      if (newToken) {
+        window.ui.preauthorizeApiKey('bearerAuth', newToken);
+        request.headers['Authorization'] = `Bearer ${newToken}`;
+        console.log('[Swagger] Access token 갱신 완료');
+      } else {
+        console.warn('[Swagger] Access token 갱신 실패 (로그인 필요)');
+      }
+
+      return request;
+    };
+  }, 300);
+})();


### PR DESCRIPTION
## Summary
- `swagger-custom.js` 추가: 요청 인터셉터로 Bearer 토큰 만료 시 `/api/auth/token/refresh` 자동 호출
- `application.yml`에 `custom-js-url: /swagger-custom.js` 등록
- 리프레시 토큰은 HttpOnly 쿠키로 자동 전송 (별도 저장 불필요)

## 동작 흐름
1. 로그인 후 accessToken → Authorize에 입력
2. 이후 토큰 만료 시 자동 갱신 (요청 인터셉터에서 처리)