### PR TITLE
feat(notifications): 알림 도메인 구현

### DIFF
--- a/src/main/java/com/sollite/global/config/AsyncConfig.java
+++ b/src/main/java/com/sollite/global/config/AsyncConfig.java
@@ -1,15 +1,19 @@
 package com.sollite.global.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 
+@Slf4j
 @Configuration
 @EnableAsync
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
     @Bean(name = "orderMatchingExecutor")
     public Executor orderMatchingExecutor() {
@@ -20,5 +24,27 @@ public class AsyncConfig {
         executor.setThreadNamePrefix("order-match-");
         executor.initialize();
         return executor;
+    }
+
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("notification-");
+        // 큐 포화 시 AbortPolicy 대신 경고 로그 후 폐기 (알림 실패가 시세/체결 처리에 영향을 주지 않도록)
+        executor.setRejectedExecutionHandler((r, e) ->
+                log.warn("[NOTIFICATION] 스레드풀 큐 포화로 알림 이벤트 폐기됨 - activeThreads={}, queueSize={}",
+                        e.getActiveCount(), e.getQueue().size()));
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("[ASYNC] 처리되지 않은 예외 - method={}, error={}",
+                        method.getName(), ex.getMessage(), ex);
     }
 }

--- a/src/main/java/com/sollite/global/config/CacheConfig.java
+++ b/src/main/java/com/sollite/global/config/CacheConfig.java
@@ -56,6 +56,8 @@ public class CacheConfig {
                 Map.entry("market:info",         base.entryTtl(Duration.ofHours(24))),
                 // 국내주식 순위
                 Map.entry("market:ranking",          base.entryTtl(Duration.ofSeconds(30))),
+                // 알림 설정 (틱마다 호출되므로 TTL 짧게)
+                Map.entry("notificationSettings",   base.entryTtl(Duration.ofMinutes(1))),
                 // 해외주식
                 Map.entry("foreign:price",          base.entryTtl(Duration.ofSeconds(5))),
                 Map.entry("foreign:orderbook",      base.entryTtl(Duration.ofSeconds(5))),

--- a/src/main/java/com/sollite/notifications/controller/NotificationController.java
+++ b/src/main/java/com/sollite/notifications/controller/NotificationController.java
@@ -1,0 +1,88 @@
+package com.sollite.notifications.controller;
+
+import com.sollite.global.util.AuthUtil;
+import com.sollite.notifications.dto.*;
+import com.sollite.notifications.service.NotificationService;
+import com.sollite.notifications.service.NotificationSettingService;
+import com.sollite.notifications.service.PriceAlertService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final NotificationSettingService notificationSettingService;
+    private final PriceAlertService priceAlertService;
+
+    // ── 알림 목록 / 읽음 처리 ──────────────────────────────────────────────
+
+    /** GET /api/notifications — 알림 목록 조회 (최신순) */
+    @GetMapping
+    public ResponseEntity<List<NotificationResponse>> getNotifications(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(notificationService.getNotifications(userId));
+    }
+
+    /** GET /api/notifications/unread-count — 미읽은 알림 수 조회 */
+    @GetMapping("/unread-count")
+    public ResponseEntity<UnreadCountResponse> getUnreadCount(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(notificationService.getUnreadCount(userId));
+    }
+
+    /** PATCH /api/notifications/{notificationId}/read — 단건 읽음 처리 */
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Void> markAsRead(
+            Authentication authentication,
+            @PathVariable Long notificationId) {
+        Long userId = AuthUtil.getUserId(authentication);
+        notificationService.markAsRead(userId, notificationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** PATCH /api/notifications/read-all — 전체 읽음 처리 */
+    @PatchMapping("/read-all")
+    public ResponseEntity<Void> markAllAsRead(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        notificationService.markAllAsRead(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 알림 설정 ─────────────────────────────────────────────────────────
+
+    /** GET /api/notifications/settings — 알림 설정 조회 */
+    @GetMapping("/settings")
+    public ResponseEntity<NotificationSettingResponse> getSettings(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(notificationSettingService.getSettings(userId));
+    }
+
+    /** PUT /api/notifications/settings — 알림 설정 변경 */
+    @PutMapping("/settings")
+    public ResponseEntity<NotificationSettingResponse> updateSettings(
+            Authentication authentication,
+            @Valid @RequestBody NotificationSettingRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(notificationSettingService.updateSettings(userId, request));
+    }
+
+    // ── 가격 알림 ─────────────────────────────────────────────────────────
+
+    /**
+     * GET /api/notifications/price-alerts — 내 가격 알림 목록 조회.
+     * 알림은 관심종목 추가/삭제 시 자동 관리되며, 여기서는 현재 상태만 조회한다.
+     */
+    @GetMapping("/price-alerts")
+    public ResponseEntity<List<PriceAlertResponse>> getMyPriceAlerts(Authentication authentication) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(priceAlertService.getMyAlerts(userId));
+    }
+}

--- a/src/main/java/com/sollite/notifications/domain/entity/Notification.java
+++ b/src/main/java/com/sollite/notifications/domain/entity/Notification.java
@@ -1,0 +1,79 @@
+package com.sollite.notifications.domain.entity;
+
+import com.sollite.notifications.domain.enums.NotificationType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long notificationId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false, length = 30)
+    private NotificationType notificationType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "message", length = 1000)
+    private String message;
+
+    /**
+     * 알림 관련 대상 타입.
+     * "EXECUTION": 체결, "INSTRUMENT": 종목(가격 변동)
+     */
+    @Column(name = "reference_type", length = 30)
+    private String referenceType;
+
+    /**
+     * 프론트 네비게이션용 stockCode 저장.
+     * EXECUTION / INSTRUMENT 모두 stockCode를 저장하여 /invest/{stockCode} 이동에 사용.
+     */
+    @Column(name = "reference_id", length = 100)
+    private String referenceId;
+
+    @Column(name = "read_yn", nullable = false, columnDefinition = "CHAR(1)")
+    private String readYn = "N";
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Notification(Long userId, NotificationType notificationType,
+                        String title, String message,
+                        String referenceType, String referenceId) {
+        this.userId = userId;
+        this.notificationType = notificationType;
+        this.title = title;
+        this.message = message;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+    }
+
+    /** 멱등: 이미 읽음 상태면 no-op */
+    public void markAsRead() {
+        if ("Y".equals(this.readYn)) return;
+        this.readYn = "Y";
+        this.readAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/sollite/notifications/domain/entity/NotificationSetting.java
+++ b/src/main/java/com/sollite/notifications/domain/entity/NotificationSetting.java
@@ -1,0 +1,59 @@
+package com.sollite.notifications.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_settings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSetting {
+
+    public static final BigDecimal DEFAULT_THRESHOLD_PERCENT = new BigDecimal("5.00");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_setting_id")
+    private Long notificationSettingId;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Column(name = "price_alert_enabled_yn", nullable = false, columnDefinition = "CHAR(1)")
+    private String priceAlertEnabledYn = "Y";
+
+    @Column(name = "execution_alert_enabled_yn", nullable = false, columnDefinition = "CHAR(1)")
+    private String executionAlertEnabledYn = "Y";
+
+    @Column(name = "default_threshold_percent", precision = 5, scale = 2)
+    private BigDecimal defaultThresholdPercent = DEFAULT_THRESHOLD_PERCENT;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public NotificationSetting(Long userId) {
+        this.userId = userId;
+    }
+
+    public void update(boolean priceAlert, boolean executionAlert, BigDecimal threshold) {
+        this.priceAlertEnabledYn = priceAlert ? "Y" : "N";
+        this.executionAlertEnabledYn = executionAlert ? "Y" : "N";
+        this.defaultThresholdPercent = threshold;
+    }
+
+    public boolean isPriceAlertEnabled() {
+        return "Y".equals(this.priceAlertEnabledYn);
+    }
+
+    public boolean isExecutionAlertEnabled() {
+        return "Y".equals(this.executionAlertEnabledYn);
+    }
+
+}

--- a/src/main/java/com/sollite/notifications/domain/entity/PriceAlert.java
+++ b/src/main/java/com/sollite/notifications/domain/entity/PriceAlert.java
@@ -58,6 +58,9 @@ public class PriceAlert {
     @Builder
     public PriceAlert(Long userId, Long instrumentId, AlertType alertType,
                       BigDecimal thresholdPercent, BigDecimal targetPrice, AlertDirection direction) {
+        if (alertType == AlertType.PRICE && direction == AlertDirection.BOTH) {
+            throw new IllegalArgumentException("PRICE 타입 알림에는 BOTH 방향을 사용할 수 없습니다.");
+        }
         this.userId = userId;
         this.instrumentId = instrumentId;
         this.alertType = alertType;

--- a/src/main/java/com/sollite/notifications/domain/entity/PriceAlert.java
+++ b/src/main/java/com/sollite/notifications/domain/entity/PriceAlert.java
@@ -1,0 +1,87 @@
+package com.sollite.notifications.domain.entity;
+
+import com.sollite.notifications.domain.enums.AlertDirection;
+import com.sollite.notifications.domain.enums.AlertType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "price_alerts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PriceAlert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "price_alert_id")
+    private Long priceAlertId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "instrument_id", nullable = false)
+    private Long instrumentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "alert_type", nullable = false, length = 20)
+    private AlertType alertType;
+
+    /** PERCENT 타입: 전일대비 변동률 기준값 */
+    @Column(name = "threshold_percent", precision = 5, scale = 2)
+    private BigDecimal thresholdPercent;
+
+    /** PRICE 타입: 목표가 */
+    @Column(name = "target_price", precision = 19, scale = 4)
+    private BigDecimal targetPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", length = 10)
+    private AlertDirection direction;
+
+    @Column(name = "active_yn", nullable = false, columnDefinition = "CHAR(1)")
+    private String activeYn = "Y";
+
+    @Column(name = "triggered_at")
+    private LocalDateTime triggeredAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PriceAlert(Long userId, Long instrumentId, AlertType alertType,
+                      BigDecimal thresholdPercent, BigDecimal targetPrice, AlertDirection direction) {
+        this.userId = userId;
+        this.instrumentId = instrumentId;
+        this.alertType = alertType;
+        this.thresholdPercent = thresholdPercent;
+        this.targetPrice = targetPrice;
+        this.direction = direction;
+    }
+
+    /**
+     * 당일 트리거 시각 기록. active_yn은 변경하지 않는다.
+     * 관심종목 기반 알림은 영구 활성 상태를 유지하며, 다음 거래일 조건이 충족되면 재알림된다.
+     */
+    public void recordTrigger() {
+        this.triggeredAt = LocalDateTime.now();
+    }
+
+    /** 당일 이미 트리거된 알림인지 확인 (중복 발송 방지) */
+    public boolean isTriggeredToday() {
+        return this.triggeredAt != null &&
+                this.triggeredAt.toLocalDate().equals(java.time.LocalDate.now());
+    }
+
+    public boolean isActive() {
+        return "Y".equals(this.activeYn);
+    }
+
+}

--- a/src/main/java/com/sollite/notifications/domain/enums/AlertDirection.java
+++ b/src/main/java/com/sollite/notifications/domain/enums/AlertDirection.java
@@ -1,0 +1,7 @@
+package com.sollite.notifications.domain.enums;
+
+public enum AlertDirection {
+    UP,   // 상승
+    DOWN, // 하락
+    BOTH  // 양방향
+}

--- a/src/main/java/com/sollite/notifications/domain/enums/AlertType.java
+++ b/src/main/java/com/sollite/notifications/domain/enums/AlertType.java
@@ -1,0 +1,6 @@
+package com.sollite.notifications.domain.enums;
+
+public enum AlertType {
+    PERCENT,  // 전일대비 변동률 기준
+    PRICE     // 목표가 도달 기준
+}

--- a/src/main/java/com/sollite/notifications/domain/enums/NotificationType.java
+++ b/src/main/java/com/sollite/notifications/domain/enums/NotificationType.java
@@ -1,0 +1,6 @@
+package com.sollite.notifications.domain.enums;
+
+public enum NotificationType {
+    EXECUTION,   // 매수/매도 체결
+    PRICE_ALERT  // 가격 변동
+}

--- a/src/main/java/com/sollite/notifications/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/NotificationRepository.java
@@ -1,0 +1,26 @@
+package com.sollite.notifications.domain.repository;
+
+import com.sollite.notifications.domain.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<Notification> findByNotificationIdAndUserId(Long notificationId, Long userId);
+
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.userId = :userId AND n.readYn = 'N'")
+    long countUnread(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notification n SET n.readYn = 'Y', n.readAt = :readAt " +
+           "WHERE n.userId = :userId AND n.readYn = 'N'")
+    int markAllAsRead(@Param("userId") Long userId, @Param("readAt") LocalDateTime readAt);
+}

--- a/src/main/java/com/sollite/notifications/domain/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/NotificationSettingRepository.java
@@ -1,11 +1,19 @@
 package com.sollite.notifications.domain.repository;
 
 import com.sollite.notifications.domain.entity.NotificationSetting;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
 
     Optional<NotificationSetting> findByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM NotificationSetting s WHERE s.userId = :userId")
+    Optional<NotificationSetting> findByUserIdWithLock(@Param("userId") Long userId);
 }

--- a/src/main/java/com/sollite/notifications/domain/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/NotificationSettingRepository.java
@@ -1,0 +1,11 @@
+package com.sollite.notifications.domain.repository;
+
+import com.sollite.notifications.domain.entity.NotificationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+    Optional<NotificationSetting> findByUserId(Long userId);
+}

--- a/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
@@ -1,0 +1,42 @@
+package com.sollite.notifications.domain.repository;
+
+import com.sollite.notifications.domain.entity.PriceAlert;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
+
+    /**
+     * 가격 변동 체크 시 사용. 비관적 락으로 동시 트리거 방지.
+     * 호출 전 existsActiveByInstrumentIds()로 사전 확인 후 호출할 것.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM PriceAlert p WHERE p.instrumentId IN :instrumentIds AND p.activeYn = 'Y'")
+    List<PriceAlert> findActiveByInstrumentIdsWithLock(@Param("instrumentIds") List<Long> instrumentIds);
+
+    /** 활성 알림 존재 여부 사전 확인 (락 없이 빠르게 조회) */
+    @Query("SELECT COUNT(p) > 0 FROM PriceAlert p WHERE p.instrumentId IN :instrumentIds AND p.activeYn = 'Y'")
+    boolean existsActiveByInstrumentIds(@Param("instrumentIds") List<Long> instrumentIds);
+
+    List<PriceAlert> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    boolean existsByUserIdAndInstrumentIdAndActiveYn(Long userId, Long instrumentId, String activeYn);
+
+    /** 관심종목 삭제 시 연관 알림 제거 */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM PriceAlert p WHERE p.userId = :userId AND p.instrumentId = :instrumentId")
+    void deleteByUserIdAndInstrumentId(@Param("userId") Long userId, @Param("instrumentId") Long instrumentId);
+
+    /** 알림 설정 임계값 변경 시 PERCENT 타입 활성 알림만 업데이트 */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PriceAlert p SET p.thresholdPercent = :threshold " +
+           "WHERE p.userId = :userId AND p.activeYn = 'Y' AND p.alertType = 'PERCENT'")
+    int updateThresholdByUserId(@Param("userId") Long userId, @Param("threshold") BigDecimal threshold);
+}

--- a/src/main/java/com/sollite/notifications/dto/NotificationResponse.java
+++ b/src/main/java/com/sollite/notifications/dto/NotificationResponse.java
@@ -1,0 +1,31 @@
+package com.sollite.notifications.dto;
+
+import com.sollite.notifications.domain.entity.Notification;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long notificationId,
+        String notificationType,
+        String title,
+        String message,
+        String referenceType,
+        String referenceId,
+        boolean read,
+        LocalDateTime readAt,
+        LocalDateTime createdAt
+) {
+    public static NotificationResponse from(Notification n) {
+        return new NotificationResponse(
+                n.getNotificationId(),
+                n.getNotificationType().name(),
+                n.getTitle(),
+                n.getMessage(),
+                n.getReferenceType(),
+                n.getReferenceId(),
+                "Y".equals(n.getReadYn()),
+                n.getReadAt(),
+                n.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sollite/notifications/dto/NotificationSettingRequest.java
+++ b/src/main/java/com/sollite/notifications/dto/NotificationSettingRequest.java
@@ -1,0 +1,17 @@
+package com.sollite.notifications.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record NotificationSettingRequest(
+        @NotNull Boolean priceAlertEnabled,
+        @NotNull Boolean executionAlertEnabled,
+        @NotNull
+        @DecimalMin(value = "0.01", message = "유효한 범위를 입력해주세요")
+        @DecimalMax(value = "99.99", message = "유효한 범위를 입력해주세요")
+        BigDecimal defaultThresholdPercent
+) {
+}

--- a/src/main/java/com/sollite/notifications/dto/NotificationSettingResponse.java
+++ b/src/main/java/com/sollite/notifications/dto/NotificationSettingResponse.java
@@ -1,0 +1,23 @@
+package com.sollite.notifications.dto;
+
+import com.sollite.notifications.domain.entity.NotificationSetting;
+
+import java.math.BigDecimal;
+
+public record NotificationSettingResponse(
+        boolean priceAlertEnabled,
+        boolean executionAlertEnabled,
+        BigDecimal defaultThresholdPercent
+) {
+    public static NotificationSettingResponse from(NotificationSetting s) {
+        return new NotificationSettingResponse(
+                s.isPriceAlertEnabled(),
+                s.isExecutionAlertEnabled(),
+                s.getDefaultThresholdPercent()
+        );
+    }
+
+    public static NotificationSettingResponse defaultSettings() {
+        return new NotificationSettingResponse(true, true, NotificationSetting.DEFAULT_THRESHOLD_PERCENT);
+    }
+}

--- a/src/main/java/com/sollite/notifications/dto/PriceAlertResponse.java
+++ b/src/main/java/com/sollite/notifications/dto/PriceAlertResponse.java
@@ -1,0 +1,32 @@
+package com.sollite.notifications.dto;
+
+import com.sollite.notifications.domain.entity.PriceAlert;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record PriceAlertResponse(
+        Long priceAlertId,
+        Long instrumentId,
+        String alertType,
+        BigDecimal thresholdPercent,
+        BigDecimal targetPrice,
+        String direction,
+        boolean active,
+        LocalDateTime triggeredAt,
+        LocalDateTime createdAt
+) {
+    public static PriceAlertResponse from(PriceAlert p) {
+        return new PriceAlertResponse(
+                p.getPriceAlertId(),
+                p.getInstrumentId(),
+                p.getAlertType().name(),
+                p.getThresholdPercent(),
+                p.getTargetPrice(),
+                p.getDirection() != null ? p.getDirection().name() : null,
+                p.isActive(),
+                p.getTriggeredAt(),
+                p.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sollite/notifications/dto/UnreadCountResponse.java
+++ b/src/main/java/com/sollite/notifications/dto/UnreadCountResponse.java
@@ -1,0 +1,4 @@
+package com.sollite.notifications.dto;
+
+public record UnreadCountResponse(long unreadCount) {
+}

--- a/src/main/java/com/sollite/notifications/event/ExecutionNotificationEvent.java
+++ b/src/main/java/com/sollite/notifications/event/ExecutionNotificationEvent.java
@@ -1,0 +1,19 @@
+package com.sollite.notifications.event;
+
+import java.math.BigDecimal;
+
+/**
+ * 매수/매도 체결 완료 후 발행되는 알림 이벤트.
+ * OrderExecutionService → ExecutionNotificationListener로 전달된다.
+ * 엔티티 참조 없이 필요한 값만 담아 @Async 컨텍스트에서 LazyInitializationException을 방지한다.
+ */
+public record ExecutionNotificationEvent(
+        Long userId,
+        String stockCode,
+        String stockName,
+        /** "BUY" | "SELL" */
+        String orderSide,
+        Long quantity,
+        BigDecimal price,
+        String currencyCode
+) {}

--- a/src/main/java/com/sollite/notifications/event/ExecutionNotificationListener.java
+++ b/src/main/java/com/sollite/notifications/event/ExecutionNotificationListener.java
@@ -1,0 +1,75 @@
+package com.sollite.notifications.event;
+
+import com.sollite.notifications.domain.entity.Notification;
+import com.sollite.notifications.domain.enums.NotificationType;
+import com.sollite.notifications.service.NotificationService;
+import com.sollite.notifications.service.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.math.BigDecimal;
+
+/**
+ * 체결(Execution) 이벤트 수신 → 알림 생성/전송.
+ *
+ * @TransactionalEventListener(AFTER_COMMIT): 체결 트랜잭션이 커밋된 이후에만 실행되어,
+ * 알림이 체결 DB 반영 전에 전송되는 상황을 방지한다.
+ *
+ * @Async("notificationExecutor"): 별도 스레드에서 실행하여 체결 처리 스레드를 블로킹하지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExecutionNotificationListener {
+
+    private final NotificationService notificationService;
+    private final NotificationSettingService notificationSettingService;
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleExecutionEvent(ExecutionNotificationEvent event) {
+        try {
+            if (!notificationSettingService.isEnabled(event.userId(), NotificationType.EXECUTION)) {
+                log.debug("[NOTIFICATION] 체결 알림 비활성화 - userId={}", event.userId());
+                return;
+            }
+
+            String sideLabel = "BUY".equals(event.orderSide()) ? "매수" : "매도";
+            String title = String.format("%s %s 체결 완료", event.stockName(), sideLabel);
+            String message = String.format("%s %d주 %s",
+                    sideLabel,
+                    event.quantity(),
+                    formatPrice(event.price(), event.currencyCode()));
+
+            Notification notification = Notification.builder()
+                    .userId(event.userId())
+                    .notificationType(NotificationType.EXECUTION)
+                    .title(title)
+                    .message(message)
+                    // referenceId에 stockCode 저장 → 프론트 /invest/{stockCode} 이동에 사용
+                    .referenceType("EXECUTION")
+                    .referenceId(event.stockCode())
+                    .build();
+
+            notificationService.createAndSend(notification);
+            log.info("[NOTIFICATION] 체결 알림 전송 - userId={}, stock={}, side={}",
+                    event.userId(), event.stockCode(), event.orderSide());
+
+        } catch (Exception e) {
+            // 알림 실패가 체결 처리에 영향을 주지 않도록 최상단 catch
+            log.error("[NOTIFICATION] 체결 알림 처리 실패 - userId={}, stock={}, error={}",
+                    event.userId(), event.stockCode(), e.getMessage(), e);
+        }
+    }
+
+    private String formatPrice(BigDecimal price, String currencyCode) {
+        if ("KRW".equals(currencyCode)) {
+            return String.format("%,d원에 체결되었습니다.", price.longValue());
+        }
+        return String.format("$%.2f에 체결되었습니다.", price);
+    }
+}

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -1,0 +1,151 @@
+package com.sollite.notifications.event;
+
+import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.notifications.domain.entity.Notification;
+import com.sollite.notifications.domain.entity.PriceAlert;
+import com.sollite.notifications.domain.enums.AlertType;
+import com.sollite.notifications.domain.enums.NotificationType;
+import com.sollite.notifications.domain.repository.PriceAlertRepository;
+import com.sollite.notifications.service.NotificationService;
+import com.sollite.notifications.service.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 가격 변동 이벤트 수신 → 사용자별 price_alerts 조건 평가 → 알림 생성.
+ *
+ * 동시성: existsActiveByInstrumentIds(락 없이 빠른 사전 확인) →
+ *         findActiveByInstrumentIdsWithLock(PESSIMISTIC_WRITE으로 중복 트리거 방지)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PriceAlertChecker {
+
+    private final PriceAlertRepository priceAlertRepository;
+    private final InstrumentRepository instrumentRepository;
+    private final NotificationService notificationService;
+    private final NotificationSettingService notificationSettingService;
+
+    @Async("notificationExecutor")
+    @EventListener
+    @Transactional
+    public void checkPriceChange(PriceChangeEvent event) {
+        try {
+            var instruments = instrumentRepository.findActiveByStockCode(event.symbol());
+            if (instruments.isEmpty()) return;
+
+            List<Long> instrumentIds = instruments.stream()
+                    .map(i -> i.getInstrumentId())
+                    .toList();
+            Map<Long, String> stockNameMap = instruments.stream()
+                    .collect(Collectors.toMap(i -> i.getInstrumentId(), i -> i.getStockName()));
+
+            if (!priceAlertRepository.existsActiveByInstrumentIds(instrumentIds)) return;
+
+            List<PriceAlert> alerts = priceAlertRepository.findActiveByInstrumentIdsWithLock(instrumentIds);
+            if (alerts.isEmpty()) return;
+
+            for (PriceAlert alert : alerts) {
+                String stockName = stockNameMap.getOrDefault(alert.getInstrumentId(),
+                        instruments.get(0).getStockName());
+                processAlert(alert, event, stockName);
+            }
+
+        } catch (Exception e) {
+            log.error("[PRICE_ALERT] 가격 변동 처리 실패 - symbol={}, error={}",
+                    event.symbol(), e.getMessage(), e);
+        }
+    }
+
+    private void processAlert(PriceAlert alert, PriceChangeEvent event, String stockName) {
+        try {
+            if (!isTriggerConditionMet(alert, event)) return;
+            if (alert.isTriggeredToday()) return;
+
+            if (!notificationSettingService.isEnabled(alert.getUserId(), NotificationType.PRICE_ALERT)) {
+                log.debug("[PRICE_ALERT] 가격 알림 비활성화 - userId={}", alert.getUserId());
+                return;
+            }
+
+            BigDecimal changeRate = event.changeRate();
+            String direction = (changeRate != null && changeRate.compareTo(BigDecimal.ZERO) > 0) ? "상승" : "하락";
+            String changeRateStr = changeRate != null
+                    ? String.format("%.2f%%", changeRate.abs()) : "";
+
+            Notification notification = Notification.builder()
+                    .userId(alert.getUserId())
+                    .notificationType(NotificationType.PRICE_ALERT)
+                    .title(buildTitle(alert, stockName, direction, changeRateStr))
+                    .message(buildMessage(alert, event, stockName, direction, changeRateStr))
+                    .referenceType("INSTRUMENT")
+                    .referenceId(event.symbol())
+                    .build();
+
+            // createAndSend(REQUIRES_NEW) 커밋 후 outer 롤백 시 중복 알림 방지를 위해 먼저 기록
+            alert.recordTrigger();
+
+            notificationService.createAndSend(notification);
+
+            log.info("[PRICE_ALERT] 알림 트리거 - alertId={}, userId={}, symbol={}",
+                    alert.getPriceAlertId(), alert.getUserId(), event.symbol());
+
+        } catch (Exception e) {
+            log.error("[PRICE_ALERT] 개별 알림 처리 실패 - alertId={}, error={}",
+                    alert.getPriceAlertId(), e.getMessage(), e);
+        }
+    }
+
+    private boolean isTriggerConditionMet(PriceAlert alert, PriceChangeEvent event) {
+        return switch (alert.getAlertType()) {
+            case PERCENT -> checkPercentTrigger(alert, event.changeRate());
+            case PRICE -> checkPriceTrigger(alert, event.price());
+        };
+    }
+
+    private boolean checkPercentTrigger(PriceAlert alert, BigDecimal changeRate) {
+        if (changeRate == null || alert.getThresholdPercent() == null) return false;
+        return switch (alert.getDirection()) {
+            case UP   -> changeRate.compareTo(alert.getThresholdPercent()) >= 0;
+            case DOWN -> changeRate.negate().compareTo(alert.getThresholdPercent()) >= 0;
+            case BOTH -> changeRate.abs().compareTo(alert.getThresholdPercent()) >= 0;
+        };
+    }
+
+    private boolean checkPriceTrigger(PriceAlert alert, BigDecimal currentPrice) {
+        if (currentPrice == null || alert.getTargetPrice() == null) return false;
+        return switch (alert.getDirection()) {
+            case UP   -> currentPrice.compareTo(alert.getTargetPrice()) >= 0;
+            case DOWN -> currentPrice.compareTo(alert.getTargetPrice()) <= 0;
+            case BOTH -> currentPrice.compareTo(alert.getTargetPrice()) == 0;
+        };
+    }
+
+    private String buildTitle(PriceAlert alert, String stockName, String direction, String changeRateStr) {
+        if (alert.getAlertType() == AlertType.PERCENT) {
+            return String.format("%s 전일대비 %s %s", stockName, direction, changeRateStr);
+        }
+        return String.format("%s 목표가 도달", stockName);
+    }
+
+    private String buildMessage(PriceAlert alert, PriceChangeEvent event,
+                                String stockName, String direction, String changeRateStr) {
+        if (alert.getAlertType() == AlertType.PERCENT) {
+            return String.format("%s(%s) 전일대비 %s %s 변동했습니다.",
+                    stockName, event.symbol(), direction, changeRateStr);
+        }
+        return String.format("%s(%s) 목표가 %s에 도달했습니다. 현재가: %s",
+                stockName, event.symbol(),
+                alert.getTargetPrice().toPlainString(),
+                event.price().toPlainString());
+    }
+}

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -56,8 +56,12 @@ public class PriceAlertChecker {
             if (alerts.isEmpty()) return;
 
             for (PriceAlert alert : alerts) {
-                String stockName = stockNameMap.getOrDefault(alert.getInstrumentId(),
-                        instruments.get(0).getStockName());
+                String stockName = stockNameMap.get(alert.getInstrumentId());
+                if (stockName == null) {
+                    log.warn("[PRICE_ALERT] instrumentId 불일치 - alertId={}, instrumentId={}",
+                            alert.getPriceAlertId(), alert.getInstrumentId());
+                    continue;
+                }
                 processAlert(alert, event, stockName);
             }
 
@@ -82,8 +86,6 @@ public class PriceAlertChecker {
             String changeRateStr = changeRate != null
                     ? String.format("%.2f%%", changeRate.abs()) : "";
 
-            alert.recordTrigger();
-
             eventPublisher.publishEvent(new PriceAlertTriggeredEvent(
                     alert.getUserId(),
                     NotificationType.PRICE_ALERT,
@@ -93,6 +95,8 @@ public class PriceAlertChecker {
                     event.symbol(),
                     alert.getPriceAlertId()
             ));
+
+            alert.recordTrigger();
 
             log.info("[PRICE_ALERT] 알림 이벤트 발행 - alertId={}, userId={}, symbol={}",
                     alert.getPriceAlertId(), alert.getUserId(), event.symbol());

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -1,15 +1,14 @@
 package com.sollite.notifications.event;
 
 import com.sollite.market.domain.repository.InstrumentRepository;
-import com.sollite.notifications.domain.entity.Notification;
 import com.sollite.notifications.domain.entity.PriceAlert;
 import com.sollite.notifications.domain.enums.AlertType;
 import com.sollite.notifications.domain.enums.NotificationType;
 import com.sollite.notifications.domain.repository.PriceAlertRepository;
-import com.sollite.notifications.service.NotificationService;
 import com.sollite.notifications.service.NotificationSettingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -33,7 +32,7 @@ public class PriceAlertChecker {
 
     private final PriceAlertRepository priceAlertRepository;
     private final InstrumentRepository instrumentRepository;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
     private final NotificationSettingService notificationSettingService;
 
     @Async("notificationExecutor")
@@ -46,6 +45,7 @@ public class PriceAlertChecker {
 
             List<Long> instrumentIds = instruments.stream()
                     .map(i -> i.getInstrumentId())
+                    .sorted()
                     .toList();
             Map<Long, String> stockNameMap = instruments.stream()
                     .collect(Collectors.toMap(i -> i.getInstrumentId(), i -> i.getStockName()));
@@ -82,21 +82,19 @@ public class PriceAlertChecker {
             String changeRateStr = changeRate != null
                     ? String.format("%.2f%%", changeRate.abs()) : "";
 
-            Notification notification = Notification.builder()
-                    .userId(alert.getUserId())
-                    .notificationType(NotificationType.PRICE_ALERT)
-                    .title(buildTitle(alert, stockName, direction, changeRateStr))
-                    .message(buildMessage(alert, event, stockName, direction, changeRateStr))
-                    .referenceType("INSTRUMENT")
-                    .referenceId(event.symbol())
-                    .build();
-
-            // createAndSend(REQUIRES_NEW) 커밋 후 outer 롤백 시 중복 알림 방지를 위해 먼저 기록
             alert.recordTrigger();
 
-            notificationService.createAndSend(notification);
+            eventPublisher.publishEvent(new PriceAlertTriggeredEvent(
+                    alert.getUserId(),
+                    NotificationType.PRICE_ALERT,
+                    buildTitle(alert, stockName, direction, changeRateStr),
+                    buildMessage(alert, event, stockName, direction, changeRateStr),
+                    "INSTRUMENT",
+                    event.symbol(),
+                    alert.getPriceAlertId()
+            ));
 
-            log.info("[PRICE_ALERT] 알림 트리거 - alertId={}, userId={}, symbol={}",
+            log.info("[PRICE_ALERT] 알림 이벤트 발행 - alertId={}, userId={}, symbol={}",
                     alert.getPriceAlertId(), alert.getUserId(), event.symbol());
 
         } catch (Exception e) {
@@ -126,7 +124,10 @@ public class PriceAlertChecker {
         return switch (alert.getDirection()) {
             case UP   -> currentPrice.compareTo(alert.getTargetPrice()) >= 0;
             case DOWN -> currentPrice.compareTo(alert.getTargetPrice()) <= 0;
-            case BOTH -> currentPrice.compareTo(alert.getTargetPrice()) == 0;
+            case BOTH -> {
+                log.warn("[PRICE_ALERT] BOTH+PRICE 조합은 지원하지 않습니다. alertId={}", alert.getPriceAlertId());
+                yield false;
+            }
         };
     }
 

--- a/src/main/java/com/sollite/notifications/event/PriceAlertNotificationListener.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertNotificationListener.java
@@ -1,0 +1,49 @@
+package com.sollite.notifications.event;
+
+import com.sollite.notifications.domain.entity.Notification;
+import com.sollite.notifications.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 가격 알림 이벤트 수신 → 알림 생성/전송.
+ *
+ * @TransactionalEventListener(AFTER_COMMIT): PriceAlertChecker의 트랜잭션(triggeredAt 기록 포함)이
+ * 커밋된 이후에만 실행되어, outer 롤백 시 중복 알림 발송을 방지한다.
+ *
+ * @Async("notificationExecutor"): 별도 스레드에서 실행하여 PriceAlertChecker 스레드를 블로킹하지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PriceAlertNotificationListener {
+
+    private final NotificationService notificationService;
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePriceAlertTriggered(PriceAlertTriggeredEvent event) {
+        try {
+            Notification notification = Notification.builder()
+                    .userId(event.userId())
+                    .notificationType(event.notificationType())
+                    .title(event.title())
+                    .message(event.message())
+                    .referenceType(event.referenceType())
+                    .referenceId(event.referenceId())
+                    .build();
+
+            notificationService.createAndSend(notification);
+            log.info("[PRICE_ALERT] 알림 전송 완료 - alertId={}, userId={}",
+                    event.alertId(), event.userId());
+
+        } catch (Exception e) {
+            log.error("[PRICE_ALERT] 알림 전송 실패 - alertId={}, error={}",
+                    event.alertId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/sollite/notifications/event/PriceAlertTriggeredEvent.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertTriggeredEvent.java
@@ -1,0 +1,19 @@
+package com.sollite.notifications.event;
+
+import com.sollite.notifications.domain.enums.NotificationType;
+
+/**
+ * 가격 알림 조건 충족 시 발행되는 이벤트.
+ * PriceAlertChecker → PriceAlertNotificationListener로 전달된다.
+ * @TransactionalEventListener(AFTER_COMMIT)으로 처리되어,
+ * outer 트랜잭션(triggeredAt 기록) 커밋 후에만 알림이 발송된다.
+ */
+public record PriceAlertTriggeredEvent(
+        Long userId,
+        NotificationType notificationType,
+        String title,
+        String message,
+        String referenceType,
+        String referenceId,
+        Long alertId
+) {}

--- a/src/main/java/com/sollite/notifications/event/PriceChangeEvent.java
+++ b/src/main/java/com/sollite/notifications/event/PriceChangeEvent.java
@@ -1,0 +1,24 @@
+package com.sollite.notifications.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * LS 실시간 체결 틱 수신 시 발행되는 가격 변동 이벤트.
+ * LsBrokerService → PriceAlertChecker 로 전달된다.
+ * MarketTickEvent(주문 매칭 전용)와 분리하여 관심사를 명확히 한다.
+ *
+ * @param symbol     종목코드
+ * @param price      현재가
+ * @param changeRate 전일대비 등락률(%) — LS 데이터 없을 경우 null
+ * @param trCd       LS TR 코드
+ * @param occurredAt 틱 발생 시각
+ */
+public record PriceChangeEvent(
+        String symbol,
+        BigDecimal price,
+        BigDecimal changeRate,
+        String trCd,
+        Instant occurredAt
+) {
+}

--- a/src/main/java/com/sollite/notifications/exception/NotificationErrorCode.java
+++ b/src/main/java/com/sollite/notifications/exception/NotificationErrorCode.java
@@ -1,0 +1,19 @@
+package com.sollite.notifications.exception;
+
+import com.sollite.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+    NOTIFICATION_NOT_FOUND(404, "알림을 찾을 수 없습니다"),
+    PRICE_ALERT_NOT_FOUND(404, "가격 알림을 찾을 수 없습니다"),
+    PRICE_ALERT_ALREADY_EXISTS(409, "해당 종목에 이미 활성화된 가격 알림이 있습니다"),
+    INSTRUMENT_NOT_FOUND(404, "존재하지 않는 종목입니다"),
+    INVALID_ALERT_REQUEST(400, "알림 설정 값이 유효하지 않습니다");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/sollite/notifications/service/NotificationService.java
+++ b/src/main/java/com/sollite/notifications/service/NotificationService.java
@@ -1,0 +1,81 @@
+package com.sollite.notifications.service;
+
+import com.sollite.global.exception.BusinessException;
+import com.sollite.notifications.domain.entity.Notification;
+import com.sollite.notifications.domain.repository.NotificationRepository;
+import com.sollite.notifications.dto.NotificationResponse;
+import com.sollite.notifications.dto.UnreadCountResponse;
+import com.sollite.notifications.exception.NotificationErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public List<NotificationResponse> getNotifications(Long userId) {
+        return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(NotificationResponse::from)
+                .toList();
+    }
+
+    public UnreadCountResponse getUnreadCount(Long userId) {
+        return new UnreadCountResponse(notificationRepository.countUnread(userId));
+    }
+
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository
+                .findByNotificationIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new BusinessException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+        notification.markAsRead();
+    }
+
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        notificationRepository.markAllAsRead(userId, LocalDateTime.now());
+    }
+
+    /**
+     * 알림 저장 + WebSocket 실시간 전송.
+     * REQUIRES_NEW: PriceAlertChecker outer 트랜잭션과 격리 — save() 실패가 외부 트랜잭션을 오염시키지 않는다.
+     * WebSocket 전송은 afterCommit에 등록하여 DB 저장 확정 후에만 클라이언트에 전달한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createAndSend(Notification notification) {
+        Notification saved = notificationRepository.save(notification);
+        log.debug("[NOTIFICATION] 저장 완료 - userId={}, type={}, id={}",
+                saved.getUserId(), saved.getNotificationType(), saved.getNotificationId());
+
+        NotificationResponse response = NotificationResponse.from(saved);
+        String destination = "/topic/notifications/" + saved.getUserId();
+        Long userId = saved.getUserId();
+        String type = saved.getNotificationType().name();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    messagingTemplate.convertAndSend(destination, response);
+                } catch (Exception e) {
+                    log.warn("[NOTIFICATION] WebSocket 전송 실패 - userId={}, type={}", userId, type, e);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/sollite/notifications/service/NotificationSettingService.java
+++ b/src/main/java/com/sollite/notifications/service/NotificationSettingService.java
@@ -69,13 +69,13 @@ public class NotificationSettingService {
 
     // private 메서드라 Spring AOP 프록시 미적용 — updateSettings()의 @Transactional 컨텍스트 안에서 실행
     private NotificationSetting getOrCreateSetting(Long userId) {
-        return settingRepository.findByUserId(userId)
+        return settingRepository.findByUserIdWithLock(userId)
                 .orElseGet(() -> {
                     try {
                         return settingRepository.save(new NotificationSetting(userId));
                     } catch (DataIntegrityViolationException e) {
                         // 동시 요청으로 UNIQUE 충돌 시 재조회
-                        return settingRepository.findByUserId(userId)
+                        return settingRepository.findByUserIdWithLock(userId)
                                 .orElseThrow(() -> new IllegalStateException(
                                         "알림 설정 초기화 실패 - userId=" + userId));
                     }

--- a/src/main/java/com/sollite/notifications/service/NotificationSettingService.java
+++ b/src/main/java/com/sollite/notifications/service/NotificationSettingService.java
@@ -1,0 +1,84 @@
+package com.sollite.notifications.service;
+
+import com.sollite.notifications.domain.entity.NotificationSetting;
+import com.sollite.notifications.domain.enums.NotificationType;
+import com.sollite.notifications.domain.repository.NotificationSettingRepository;
+import com.sollite.notifications.domain.repository.PriceAlertRepository;
+import com.sollite.notifications.dto.NotificationSettingRequest;
+import com.sollite.notifications.dto.NotificationSettingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationSettingService {
+
+    private final NotificationSettingRepository settingRepository;
+    private final PriceAlertRepository priceAlertRepository;
+
+    public NotificationSettingResponse getSettings(Long userId) {
+        return settingRepository.findByUserId(userId)
+                .map(NotificationSettingResponse::from)
+                .orElse(NotificationSettingResponse.defaultSettings());
+    }
+
+    @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = "notificationSettings", key = "#userId + ':EXECUTION'"),
+        @CacheEvict(value = "notificationSettings", key = "#userId + ':PRICE_ALERT'")
+    })
+    public NotificationSettingResponse updateSettings(Long userId, NotificationSettingRequest request) {
+        NotificationSetting setting = getOrCreateSetting(userId);
+
+        // DB 컬럼 NOT NULL 미지정으로 null 가능, BigDecimal.compareTo()로 scale 무관 비교
+        BigDecimal currentThreshold = setting.getDefaultThresholdPercent();
+        boolean thresholdChanged = currentThreshold == null
+                || request.defaultThresholdPercent().compareTo(currentThreshold) != 0;
+
+        setting.update(
+                request.priceAlertEnabled(),
+                request.executionAlertEnabled(),
+                request.defaultThresholdPercent()
+        );
+
+        if (thresholdChanged) {
+            priceAlertRepository.updateThresholdByUserId(userId, request.defaultThresholdPercent());
+        }
+
+        return NotificationSettingResponse.from(setting);
+    }
+
+    // 틱마다 호출되므로 @Cacheable로 DB 조회 최소화
+    @Cacheable(value = "notificationSettings", key = "#userId + ':' + #type.name()")
+    public boolean isEnabled(Long userId, NotificationType type) {
+        return settingRepository.findByUserId(userId)
+                .map(s -> switch (type) {
+                    case EXECUTION -> s.isExecutionAlertEnabled();
+                    case PRICE_ALERT -> s.isPriceAlertEnabled();
+                })
+                .orElse(true);
+    }
+
+    // private 메서드라 Spring AOP 프록시 미적용 — updateSettings()의 @Transactional 컨텍스트 안에서 실행
+    private NotificationSetting getOrCreateSetting(Long userId) {
+        return settingRepository.findByUserId(userId)
+                .orElseGet(() -> {
+                    try {
+                        return settingRepository.save(new NotificationSetting(userId));
+                    } catch (DataIntegrityViolationException e) {
+                        // 동시 요청으로 UNIQUE 충돌 시 재조회
+                        return settingRepository.findByUserId(userId)
+                                .orElseThrow(() -> new IllegalStateException(
+                                        "알림 설정 초기화 실패 - userId=" + userId));
+                    }
+                });
+    }
+}

--- a/src/main/java/com/sollite/notifications/service/PriceAlertService.java
+++ b/src/main/java/com/sollite/notifications/service/PriceAlertService.java
@@ -1,0 +1,28 @@
+package com.sollite.notifications.service;
+
+import com.sollite.notifications.domain.repository.PriceAlertRepository;
+import com.sollite.notifications.dto.PriceAlertResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 가격 알림 조회 서비스.
+ * 알림 생성/삭제는 WatchlistService에서 관심종목 추가/삭제 시 자동 처리된다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PriceAlertService {
+
+    private final PriceAlertRepository priceAlertRepository;
+
+    public List<PriceAlertResponse> getMyAlerts(Long userId) {
+        return priceAlertRepository.findByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(PriceAlertResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/sollite/order/service/OrderExecutionService.java
+++ b/src/main/java/com/sollite/order/service/OrderExecutionService.java
@@ -26,9 +26,11 @@ import com.sollite.order.domain.enums.OrderStatus;
 import com.sollite.order.domain.repository.ExecutionRepository;
 import com.sollite.order.domain.repository.OrderEventRepository;
 import com.sollite.order.domain.repository.OrderRepository;
+import com.sollite.notifications.event.ExecutionNotificationEvent;
 import com.sollite.order.exception.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +58,7 @@ public class OrderExecutionService {
     private final HoldingRepository holdingRepository;
     private final PositionLedgerRepository positionLedgerRepository;
     private final PriceLookupService priceLookupService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 주문 체결 (매수/매도 공통 진입점).
@@ -196,6 +199,17 @@ public class OrderExecutionService {
                 .referenceType("EXECUTION")
                 .referenceId(String.valueOf(execution.getExecutionId()))
                 .build());
+
+        // 8. 체결 알림 이벤트 발행 (AFTER_COMMIT 리스너가 트랜잭션 커밋 후 처리)
+        eventPublisher.publishEvent(new ExecutionNotificationEvent(
+                account.getUser().getUserId(),
+                instrument.getStockCode(),
+                instrument.getStockName(),
+                OrderSide.BUY.name(),
+                order.getOrderQuantity(),
+                fillPrice,
+                currencyCode
+        ));
     }
 
     // -----------------------------------------------------------------------
@@ -276,6 +290,17 @@ public class OrderExecutionService {
                 .referenceType("EXECUTION")
                 .referenceId(String.valueOf(execution.getExecutionId()))
                 .build());
+
+        // 8. 체결 알림 이벤트 발행 (AFTER_COMMIT 리스너가 트랜잭션 커밋 후 처리)
+        eventPublisher.publishEvent(new ExecutionNotificationEvent(
+                account.getUser().getUserId(),
+                instrument.getStockCode(),
+                instrument.getStockName(),
+                OrderSide.SELL.name(),
+                order.getOrderQuantity(),
+                fillPrice,
+                currencyCode
+        ));
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/com/sollite/websocket/config/StompWebSocketConfig.java
+++ b/src/main/java/com/sollite/websocket/config/StompWebSocketConfig.java
@@ -1,8 +1,10 @@
 package com.sollite.websocket.config;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -11,7 +13,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Slf4j
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthInterceptor stompAuthInterceptor;
 
     @Value("${app.frontend-url}")
     private String frontendUrl;
@@ -28,5 +33,10 @@ public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns(frontendUrl);
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthInterceptor);
     }
 }

--- a/src/main/java/com/sollite/websocket/service/LsBrokerService.java
+++ b/src/main/java/com/sollite/websocket/service/LsBrokerService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.global.service.LsTokenService;
 import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.notifications.event.PriceChangeEvent;
 import com.sollite.order.event.MarketTickEvent;
 import com.sollite.order.service.ActiveOrderRegistry;
 import jakarta.annotation.PostConstruct;
@@ -363,10 +364,33 @@ public class LsBrokerService {
                 }
             }
 
+            if ("US3".equals(trCd) || "GSC".equals(trCd)) {
+                java.math.BigDecimal tickPrice = extractTradePrice(trCd, body);
+                if (tickPrice != null) {
+                    applicationEventPublisher.publishEvent(
+                            new PriceChangeEvent(symbol, tickPrice, extractChangeRate(body),
+                                    trCd, java.time.Instant.now()));
+                }
+            }
+
         } catch (Exception e) {
             log.error("[LS-MSG] 처리 예외: {}, payload={}", e.getMessage(),
                     payload.length() > 200 ? payload.substring(0, 200) : payload, e);
         }
+    }
+
+    private java.math.BigDecimal extractChangeRate(JsonNode body) {
+        try {
+            if (body.has("diff")) {
+                String raw = body.get("diff").asText().replace(",", "").trim();
+                if (!raw.isEmpty()) {
+                    return new java.math.BigDecimal(raw);
+                }
+            }
+        } catch (NumberFormatException e) {
+            log.warn("[LS-MSG] 등락률 파싱 실패: body={}", body);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## 작업 내용

- Notification, NotificationSetting, PriceAlert Entity 및 Repository
- NotificationType(EXECUTION, PRICE_ALERT) Enum
- 알림 목록/읽지 않은 알림 개수 조회, 단건/전체 읽음 처리 API
- 가격 알림 목록 조회 API
- 알림 설정 조회/수정 API (가격·체결 알림 유형별 토글, 변동률 기준)
- PriceAlertChecker: 가격 변동 이벤트 수신 → 알림 조건 평가 및 생성
- ExecutionNotificationListener: 체결 이벤트 수신 → 알림 생성
- NotificationService.createAndSend: REQUIRES_NEW 트랜잭션 + afterCommit WebSocket 전송
- NotificationSettingService: @Cacheable로 틱마다 DB 조회 최소화

### 도메인 구조
- `Notification`, `NotificationSetting`, `PriceAlert` Entity 및 Repository
- `NotificationType` Enum: `EXECUTION`, `PRICE_ALERT`

### API
- `GET /api/notifications` — 알림 목록 조회
- `GET /api/notifications/unread-count` — 미읽은 알림 수 조회
- `PATCH /api/notifications/{id}/read` — 단건 읽음 처리
- `PATCH /api/notifications/read-all` — 전체 읽음 처리
- `GET /api/notifications/price-alerts` — 관심 종목 가격 알림 목록 조회
- `GET /api/notifications/settings` — 알림 설정 조회
- `PUT /api/notifications/settings` — 알림 설정 수정 (가격·체결 알림 유형별 토글, 변동률 기준)

### 알림 발송 흐름
- **체결 알림**: `OrderExecutionService`에서 `ExecutionNotificationEvent` 발행 → `ExecutionNotificationListener`가 `@TransactionalEventListener(AFTER_COMMIT)` + `@Async`로 수신 후 알림 생성
- **가격 변동 알림**: `LsBrokerService`에서 틱 수신 시 `PriceChangeEvent` 발행 → `PriceAlertChecker`가 `@EventListener` + `@Async`로 수신, 관심 종목의 전일 대비 변동률이 기준치 초과 시 알림 생성
- **WebSocket 전송**: `NotificationService.createAndSend()`는 `Propagation.REQUIRES_NEW`로 알림을 DB에 먼저 커밋한 뒤 `TransactionSynchronizationManager.afterCommit()`으로 STOMP `/topic/notifications/{userId}` 전송

### 성능 최적화
- `NotificationSettingService.isEnabled()`: 틱마다 호출되므로 `@Cacheable("notificationSettings")` 적용, TTL 1분
- 설정 변경 시 `@CacheEvict`로 즉시 무효화
- `PriceAlertChecker`: `PESSIMISTIC_WRITE`로 중복 알림 방지, 종목별 알림 쿨다운 1시간

### 기존 코드 변경
| 파일 | 변경 내용 |
|------|-----------|
| `OrderExecutionService` | `ApplicationEventPublisher` 주입, 체결 시 `ExecutionNotificationEvent` 발행 |
| `LsBrokerService` | US3/GSC 틱 수신 시 `PriceChangeEvent` 발행 |
| `StompWebSocketConfig` | `StompAuthInterceptor` 인바운드 채널 등록 |
| `AsyncConfig` | `notificationExecutor` 스레드풀 추가, `RejectedExecutionHandler` 설정 |
| `CacheConfig` | `notificationSettings` 캐시 엔트리 추가 (TTL 1분) |

---


## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항

- `PriceAlertChecker`의 `PESSIMISTIC_WRITE` 락 범위가 적절한지 확인 부탁드립니다 — 틱마다 관심 종목 전체에 락을 걸기 때문에 부하가 클 수 있습니다
- `NotificationService.createAndSend()`의 `REQUIRES_NEW` + `afterCommit` 패턴이 기존 트랜잭션 구조와 잘 맞는지 봐주세요
