### PR TITLE
fix(notifications): STOMP 인증 인터셉터 추가 및 알림 기능 구조 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'  // WebClient (한투 API)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // ── Oracle JDBC ──
     implementation 'com.oracle.database.jdbc:ojdbc11:23.6.0.24.10'

--- a/src/main/java/com/sollite/global/config/AsyncConfig.java
+++ b/src/main/java/com/sollite/global/config/AsyncConfig.java
@@ -26,6 +26,20 @@ public class AsyncConfig implements AsyncConfigurer {
         return executor;
     }
 
+    @Bean(name = "priceCheckExecutor")
+    public Executor priceCheckExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(1000);
+        executor.setThreadNamePrefix("price-check-");
+        executor.setRejectedExecutionHandler((r, e) ->
+                log.warn("[PRICE_CHECK] 스레드풀 큐 포화로 가격 체크 이벤트 폐기됨 - activeThreads={}, queueSize={}",
+                        e.getActiveCount(), e.getQueue().size()));
+        executor.initialize();
+        return executor;
+    }
+
     @Bean(name = "notificationExecutor")
     public Executor notificationExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/src/main/java/com/sollite/global/config/AsyncConfig.java
+++ b/src/main/java/com/sollite/global/config/AsyncConfig.java
@@ -47,7 +47,6 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(4);
         executor.setQueueCapacity(200);
         executor.setThreadNamePrefix("notification-");
-        // 큐 포화 시 AbortPolicy 대신 경고 로그 후 폐기 (알림 실패가 시세/체결 처리에 영향을 주지 않도록)
         executor.setRejectedExecutionHandler((r, e) ->
                 log.warn("[NOTIFICATION] 스레드풀 큐 포화로 알림 이벤트 폐기됨 - activeThreads={}, queueSize={}",
                         e.getActiveCount(), e.getQueue().size()));

--- a/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
@@ -34,9 +34,23 @@ public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
     @Query("DELETE FROM PriceAlert p WHERE p.userId = :userId AND p.instrumentId = :instrumentId")
     void deleteByUserIdAndInstrumentId(@Param("userId") Long userId, @Param("instrumentId") Long instrumentId);
 
-    /** 서버 기동 시 활성 알림의 instrumentId 목록 조회 (ActivePriceAlertRegistry 복구용) */
-    @Query("SELECT DISTINCT p.instrumentId FROM PriceAlert p WHERE p.activeYn = 'Y'")
-    List<Long> findAllActiveInstrumentIds();
+    /**
+     * 서버 기동 시 종목별 활성 알림 수 집계 (ActivePriceAlertRegistry 복구용).
+     * 카운터 기반 레지스트리에 실제 알림 수만큼 register()를 호출하기 위해 사용한다.
+     * result[0] = instrumentId (Long), result[1] = count (Long)
+     */
+    @Query("SELECT p.instrumentId, COUNT(p) FROM PriceAlert p WHERE p.activeYn = 'Y' GROUP BY p.instrumentId")
+    List<Object[]> countActiveGroupedByInstrumentId();
+
+    /**
+     * 당일 미트리거 활성 알림 존재 여부 확인 (락 없이 빠르게 조회).
+     * 당일 이미 전부 트리거된 종목은 이 단계에서 조기 종료하여 PESSIMISTIC_WRITE 락 진입을 방지한다.
+     */
+    @Query("SELECT COUNT(p) > 0 FROM PriceAlert p WHERE p.instrumentId IN :instrumentIds " +
+           "AND p.activeYn = 'Y' AND (p.triggeredAt IS NULL OR p.triggeredAt < :todayStart)")
+    boolean existsUntriggeredTodayByInstrumentIds(
+            @Param("instrumentIds") List<Long> instrumentIds,
+            @Param("todayStart") java.time.LocalDateTime todayStart);
 
     /** 알림 설정 임계값 변경 시 PERCENT 타입 활성 알림만 업데이트 */
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
@@ -34,6 +34,10 @@ public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
     @Query("DELETE FROM PriceAlert p WHERE p.userId = :userId AND p.instrumentId = :instrumentId")
     void deleteByUserIdAndInstrumentId(@Param("userId") Long userId, @Param("instrumentId") Long instrumentId);
 
+    /** 서버 기동 시 활성 알림의 instrumentId 목록 조회 (ActivePriceAlertRegistry 복구용) */
+    @Query("SELECT DISTINCT p.instrumentId FROM PriceAlert p WHERE p.activeYn = 'Y'")
+    List<Long> findAllActiveInstrumentIds();
+
     /** 알림 설정 임계값 변경 시 PERCENT 타입 활성 알림만 업데이트 */
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PriceAlert p SET p.thresholdPercent = :threshold " +

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -9,23 +9,37 @@ import com.sollite.notifications.service.ActivePriceAlertRegistry;
 import com.sollite.notifications.service.NotificationSettingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
  * 가격 변동 이벤트 수신 → 사용자별 price_alerts 조건 평가 → 알림 생성.
  *
- * 동시성: existsActiveByInstrumentIds(락 없이 빠른 사전 확인) →
- *         findActiveByInstrumentIdsWithLock(PESSIMISTIC_WRITE으로 중복 트리거 방지)
+ * [latest-only 처리]
+ * 같은 종목에 대해 처리 중인 작업이 있으면 새 틱은 latestPending만 갱신하고 큐에 추가하지 않는다.
+ * 작업 완료 후 pending이 남아있으면 즉시 재제출하여 최신 틱 한 번만 처리한다.
+ * 이로써 틱이 빠른 종목에서 큐 적재량을 종목 수 기준으로 억제한다.
+ *
+ * [동시성]
+ * existsActiveByInstrumentIds(락 없이 빠른 사전 확인) →
+ * findActiveByInstrumentIdsWithLock(PESSIMISTIC_WRITE으로 중복 트리거 방지)
  */
 @Slf4j
 @Component
@@ -39,57 +53,118 @@ public class PriceAlertChecker {
     private final ActivePriceAlertRegistry activePriceAlertRegistry;
 
     /**
+     * 종목별 최신 틱 이벤트 버퍼.
+     * 처리 중인 작업이 있을 때 새 틱이 오면 이 맵만 갱신하고 큐에 추가하지 않는다.
+     */
+    private final Map<String, PriceChangeEvent> latestPending = new ConcurrentHashMap<>();
+
+    /**
+     * 현재 처리 중이거나 큐에 제출된 종목 집합.
+     * add()가 true를 반환한 스레드만 해당 종목의 작업을 제출한다.
+     */
+    private final Set<String> activeSymbols = ConcurrentHashMap.newKeySet();
+
+    /**
+     * @Async 프록시를 통한 self 호출을 위해 지연 주입.
+     * @RequiredArgsConstructor 생성자에 포함되지 않는다.
+     */
+    @Lazy
+    @Autowired
+    private PriceAlertChecker self;
+
+    /**
      * 서버 기동 완료 후 DB의 활성 가격 알림 종목을 레지스트리에 복구한다.
-     * LsBrokerService의 PriceChangeEvent 필터링이 정상 동작하도록 보장한다.
+     * 종목별 실제 알림 수만큼 register()를 호출하여 카운터를 정확히 복구한다.
+     * (1회만 호출하면 unregister 시 다른 사용자의 알림이 누락될 수 있음)
      */
     @EventListener(ApplicationReadyEvent.class)
     @Transactional(readOnly = true)
     public void recoverRegistry() {
-        List<Long> instrumentIds = priceAlertRepository.findAllActiveInstrumentIds();
-        if (instrumentIds.isEmpty()) {
+        List<Object[]> rows = priceAlertRepository.countActiveGroupedByInstrumentId();
+        if (rows.isEmpty()) {
             log.info("[PRICE_ALERT] 활성 가격 알림 없음 — 레지스트리 복구 스킵");
             return;
         }
 
-        instrumentRepository.findAllById(instrumentIds).forEach(instrument ->
-                activePriceAlertRegistry.register(instrument.getStockCode()));
+        // instrumentId → 활성 알림 수
+        Map<Long, Long> countByInstrumentId = new HashMap<>();
+        for (Object[] row : rows) {
+            countByInstrumentId.put((Long) row[0], (Long) row[1]);
+        }
 
-        log.info("[PRICE_ALERT] 가격 알림 레지스트리 복구 완료 — 종목 수={}", instrumentIds.size());
+        instrumentRepository.findAllById(countByInstrumentId.keySet()).forEach(instrument -> {
+            long count = countByInstrumentId.get(instrument.getInstrumentId());
+            for (long i = 0; i < count; i++) {
+                activePriceAlertRegistry.register(instrument.getStockCode());
+            }
+        });
+
+        log.info("[PRICE_ALERT] 가격 알림 레지스트리 복구 완료 — 종목 수={}, 총 알림 수={}",
+                countByInstrumentId.size(),
+                countByInstrumentId.values().stream().mapToLong(Long::longValue).sum());
     }
 
-    @Async("priceCheckExecutor")
+    /**
+     * 틱 이벤트 수신 (reactor-http-nio 스레드에서 동기 실행 — O(1), DB 없음).
+     * latestPending을 갱신하고, 해당 종목의 작업이 없으면 priceCheckExecutor에 제출한다.
+     */
     @EventListener
+    public void onPriceChange(PriceChangeEvent event) {
+        latestPending.put(event.symbol(), event);
+        if (activeSymbols.add(event.symbol())) {
+            self.processLatest(event.symbol());
+        }
+    }
+
+    /**
+     * 종목의 최신 틱 이벤트를 꺼내 조건을 평가한다.
+     * 처리 완료 후 새 틱이 도착해 있으면 즉시 재제출하여 최신 틱 한 번을 더 처리한다.
+     */
+    @Async("priceCheckExecutor")
     @Transactional
-    public void checkPriceChange(PriceChangeEvent event) {
+    public void processLatest(String symbol) {
         try {
-            var instruments = instrumentRepository.findActiveByStockCode(event.symbol());
-            if (instruments.isEmpty()) return;
-
-            List<Long> instrumentIds = instruments.stream()
-                    .map(i -> i.getInstrumentId())
-                    .sorted()
-                    .toList();
-            Map<Long, String> stockNameMap = instruments.stream()
-                    .collect(Collectors.toMap(i -> i.getInstrumentId(), i -> i.getStockName()));
-
-            if (!priceAlertRepository.existsActiveByInstrumentIds(instrumentIds)) return;
-
-            List<PriceAlert> alerts = priceAlertRepository.findActiveByInstrumentIdsWithLock(instrumentIds);
-            if (alerts.isEmpty()) return;
-
-            for (PriceAlert alert : alerts) {
-                String stockName = stockNameMap.get(alert.getInstrumentId());
-                if (stockName == null) {
-                    log.warn("[PRICE_ALERT] instrumentId 불일치 - alertId={}, instrumentId={}",
-                            alert.getPriceAlertId(), alert.getInstrumentId());
-                    continue;
-                }
-                processAlert(alert, event, stockName);
-            }
-
+            PriceChangeEvent event = latestPending.remove(symbol);
+            if (event == null) return;
+            doCheckPriceChange(event);
         } catch (Exception e) {
             log.error("[PRICE_ALERT] 가격 변동 처리 실패 - symbol={}, error={}",
-                    event.symbol(), e.getMessage(), e);
+                    symbol, e.getMessage(), e);
+        } finally {
+            activeSymbols.remove(symbol);
+            // 처리 중 새 틱이 도착했으면 재제출
+            if (latestPending.containsKey(symbol) && activeSymbols.add(symbol)) {
+                self.processLatest(symbol);
+            }
+        }
+    }
+
+    private void doCheckPriceChange(PriceChangeEvent event) {
+        var instruments = instrumentRepository.findActiveByStockCode(event.symbol());
+        if (instruments.isEmpty()) return;
+
+        List<Long> instrumentIds = instruments.stream()
+                .map(i -> i.getInstrumentId())
+                .sorted()
+                .toList();
+        Map<Long, String> stockNameMap = instruments.stream()
+                .collect(Collectors.toMap(i -> i.getInstrumentId(), i -> i.getStockName()));
+
+        // 당일 미트리거 알림이 없으면 PESSIMISTIC_WRITE 락 진입 생략
+        LocalDateTime todayStart = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT);
+        if (!priceAlertRepository.existsUntriggeredTodayByInstrumentIds(instrumentIds, todayStart)) return;
+
+        List<PriceAlert> alerts = priceAlertRepository.findActiveByInstrumentIdsWithLock(instrumentIds);
+        if (alerts.isEmpty()) return;
+
+        for (PriceAlert alert : alerts) {
+            String stockName = stockNameMap.get(alert.getInstrumentId());
+            if (stockName == null) {
+                log.warn("[PRICE_ALERT] instrumentId 불일치 - alertId={}, instrumentId={}",
+                        alert.getPriceAlertId(), alert.getInstrumentId());
+                continue;
+            }
+            processAlert(alert, event, stockName);
         }
     }
 

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -5,9 +5,11 @@ import com.sollite.notifications.domain.entity.PriceAlert;
 import com.sollite.notifications.domain.enums.AlertType;
 import com.sollite.notifications.domain.enums.NotificationType;
 import com.sollite.notifications.domain.repository.PriceAlertRepository;
+import com.sollite.notifications.service.ActivePriceAlertRegistry;
 import com.sollite.notifications.service.NotificationSettingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -34,8 +36,28 @@ public class PriceAlertChecker {
     private final InstrumentRepository instrumentRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final NotificationSettingService notificationSettingService;
+    private final ActivePriceAlertRegistry activePriceAlertRegistry;
 
-    @Async("notificationExecutor")
+    /**
+     * 서버 기동 완료 후 DB의 활성 가격 알림 종목을 레지스트리에 복구한다.
+     * LsBrokerService의 PriceChangeEvent 필터링이 정상 동작하도록 보장한다.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional(readOnly = true)
+    public void recoverRegistry() {
+        List<Long> instrumentIds = priceAlertRepository.findAllActiveInstrumentIds();
+        if (instrumentIds.isEmpty()) {
+            log.info("[PRICE_ALERT] 활성 가격 알림 없음 — 레지스트리 복구 스킵");
+            return;
+        }
+
+        instrumentRepository.findAllById(instrumentIds).forEach(instrument ->
+                activePriceAlertRegistry.register(instrument.getStockCode()));
+
+        log.info("[PRICE_ALERT] 가격 알림 레지스트리 복구 완료 — 종목 수={}", instrumentIds.size());
+    }
+
+    @Async("priceCheckExecutor")
     @EventListener
     @Transactional
     public void checkPriceChange(PriceChangeEvent event) {

--- a/src/main/java/com/sollite/notifications/event/PriceAlertNotificationListener.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertNotificationListener.java
@@ -35,7 +35,7 @@ public class PriceAlertNotificationListener {
 
     private static final Duration DEDUP_WINDOW = Duration.ofMinutes(1);
 
-    /** 최근 전송된 알림 키 → 전송 시각. 키: userId:notificationType:referenceId */
+    /** 최근 전송된 알림 키 → 전송 시각. 키: userId:notificationType:alertId */
     private final Map<String, Instant> recentlySent = new ConcurrentHashMap<>();
 
     @Async("notificationExecutor")
@@ -69,20 +69,20 @@ public class PriceAlertNotificationListener {
      */
     private boolean isDuplicate(PriceAlertTriggeredEvent event) {
         Instant now = Instant.now();
-        String key = event.userId() + ":" + event.notificationType() + ":" + event.referenceId();
+        // alertId 기준으로 키 구성 — 같은 종목에 여러 알림(목표가+등락률)이 동시 충족되어도 각각 독립 처리
+        String key = event.userId() + ":" + event.notificationType() + ":" + event.alertId();
 
         // 만료 항목 정리
         recentlySent.entrySet().removeIf(e ->
                 Duration.between(e.getValue(), now).compareTo(DEDUP_WINDOW) >= 0);
 
-        Instant lastSent = recentlySent.get(key);
-        if (lastSent != null && Duration.between(lastSent, now).compareTo(DEDUP_WINDOW) < 0) {
-            log.debug("[PRICE_ALERT] 중복 알림 억제 - userId={}, symbol={}",
-                    event.userId(), event.referenceId());
+        // putIfAbsent: 원자적으로 키 등록 — 동시 스레드가 같은 키를 동시에 처리해도 하나만 통과
+        Instant existing = recentlySent.putIfAbsent(key, now);
+        if (existing != null && Duration.between(existing, now).compareTo(DEDUP_WINDOW) < 0) {
+            log.debug("[PRICE_ALERT] 중복 알림 억제 - userId={}, alertId={}",
+                    event.userId(), event.alertId());
             return true;
         }
-
-        recentlySent.put(key, now);
         return false;
     }
 }

--- a/src/main/java/com/sollite/notifications/event/PriceAlertNotificationListener.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertNotificationListener.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * 가격 알림 이벤트 수신 → 알림 생성/전송.
  *
@@ -16,6 +21,10 @@ import org.springframework.transaction.event.TransactionalEventListener;
  * 커밋된 이후에만 실행되어, outer 롤백 시 중복 알림 발송을 방지한다.
  *
  * @Async("notificationExecutor"): 별도 스레드에서 실행하여 PriceAlertChecker 스레드를 블로킹하지 않는다.
+ *
+ * [중복 억제]
+ * isTriggeredToday() + PESSIMISTIC_WRITE으로 1차 중복이 차단되지만,
+ * 예외적인 재시도 상황에 대비해 인메모리 시간 윈도우(1분) 기반 중복 억제를 추가로 적용한다.
  */
 @Slf4j
 @Component
@@ -24,10 +33,17 @@ public class PriceAlertNotificationListener {
 
     private final NotificationService notificationService;
 
+    private static final Duration DEDUP_WINDOW = Duration.ofMinutes(1);
+
+    /** 최근 전송된 알림 키 → 전송 시각. 키: userId:notificationType:referenceId */
+    private final Map<String, Instant> recentlySent = new ConcurrentHashMap<>();
+
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePriceAlertTriggered(PriceAlertTriggeredEvent event) {
         try {
+            if (isDuplicate(event)) return;
+
             Notification notification = Notification.builder()
                     .userId(event.userId())
                     .notificationType(event.notificationType())
@@ -45,5 +61,28 @@ public class PriceAlertNotificationListener {
             log.error("[PRICE_ALERT] 알림 전송 실패 - alertId={}, error={}",
                     event.alertId(), e.getMessage(), e);
         }
+    }
+
+    /**
+     * 동일 사용자/종목/알림 타입의 알림이 DEDUP_WINDOW 내에 이미 전송됐으면 true 반환.
+     * 만료된 항목을 함께 정리한다.
+     */
+    private boolean isDuplicate(PriceAlertTriggeredEvent event) {
+        Instant now = Instant.now();
+        String key = event.userId() + ":" + event.notificationType() + ":" + event.referenceId();
+
+        // 만료 항목 정리
+        recentlySent.entrySet().removeIf(e ->
+                Duration.between(e.getValue(), now).compareTo(DEDUP_WINDOW) >= 0);
+
+        Instant lastSent = recentlySent.get(key);
+        if (lastSent != null && Duration.between(lastSent, now).compareTo(DEDUP_WINDOW) < 0) {
+            log.debug("[PRICE_ALERT] 중복 알림 억제 - userId={}, symbol={}",
+                    event.userId(), event.referenceId());
+            return true;
+        }
+
+        recentlySent.put(key, now);
+        return false;
     }
 }

--- a/src/main/java/com/sollite/notifications/service/ActivePriceAlertRegistry.java
+++ b/src/main/java/com/sollite/notifications/service/ActivePriceAlertRegistry.java
@@ -1,0 +1,38 @@
+package com.sollite.notifications.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 활성 가격 알림이 존재하는 종목을 카운터 기반으로 추적한다.
+ * <p>
+ * LsBrokerService가 PriceChangeEvent 발행 전 이 레지스트리를 확인하여,
+ * 가격 알림이 없는 종목의 틱 이벤트를 priceCheckExecutor 큐에 적재하지 않도록 한다.
+ * 동일 종목에 여러 사용자의 알림이 있을 수 있으므로 카운터로 관리한다.
+ */
+@Component
+public class ActivePriceAlertRegistry {
+
+    // stockCode → 활성 알림 수
+    private final Map<String, AtomicInteger> counts = new ConcurrentHashMap<>();
+
+    public void register(String stockCode) {
+        counts.computeIfAbsent(stockCode, k -> new AtomicInteger(0))
+              .incrementAndGet();
+    }
+
+    public void unregister(String stockCode) {
+        counts.computeIfPresent(stockCode, (k, cnt) -> {
+            if (cnt.decrementAndGet() <= 0) return null;
+            return cnt;
+        });
+    }
+
+    public boolean hasActiveAlerts(String stockCode) {
+        AtomicInteger cnt = counts.get(stockCode);
+        return cnt != null && cnt.get() > 0;
+    }
+}

--- a/src/main/java/com/sollite/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/sollite/watchlist/service/WatchlistService.java
@@ -6,6 +6,13 @@ import com.sollite.market.domain.entity.Instrument;
 import com.sollite.market.domain.repository.InstrumentRepository;
 import com.sollite.market.dto.CurrentPriceResponse;
 import com.sollite.market.service.MarketService;
+import com.sollite.notifications.domain.entity.NotificationSetting;
+import com.sollite.notifications.domain.entity.PriceAlert;
+import com.sollite.notifications.domain.enums.AlertDirection;
+import com.sollite.notifications.domain.enums.AlertType;
+import com.sollite.notifications.domain.repository.NotificationSettingRepository;
+import com.sollite.notifications.domain.repository.PriceAlertRepository;
+import com.sollite.notifications.service.ActivePriceAlertRegistry;
 import com.sollite.watchlist.domain.entity.WatchlistItem;
 import com.sollite.watchlist.domain.repository.WatchlistItemRepository;
 import com.sollite.watchlist.dto.WatchlistAddRequest;
@@ -18,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Slf4j
@@ -33,6 +41,9 @@ public class WatchlistService {
     private final MarketService marketService;
     private final LsBrokerService lsBrokerService;
     private final ObjectMapper objectMapper;
+    private final PriceAlertRepository priceAlertRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
+    private final ActivePriceAlertRegistry activePriceAlertRegistry;
 
     public List<WatchlistItemResponse> getWatchlist(Long userId) {
         return watchlistItemRepository.findByUserIdOrderByDisplayOrderAsc(userId)
@@ -92,14 +103,36 @@ public class WatchlistService {
 
         int nextOrder = watchlistItemRepository.findMaxDisplayOrderByUserId(userId) + 1;
         watchlistItemRepository.save(WatchlistItem.create(userId, instrument, nextOrder));
+
+        // 관심종목 추가 시 가격 알림 자동 생성 (사용자 기본 임계값 적용)
+        BigDecimal threshold = notificationSettingRepository.findByUserId(userId)
+                .map(NotificationSetting::getDefaultThresholdPercent)
+                .orElse(NotificationSetting.DEFAULT_THRESHOLD_PERCENT);
+        priceAlertRepository.save(PriceAlert.builder()
+                .userId(userId)
+                .instrumentId(instrument.getInstrumentId())
+                .alertType(AlertType.PERCENT)
+                .thresholdPercent(threshold)
+                .direction(AlertDirection.BOTH)
+                .build());
+        activePriceAlertRegistry.register(instrument.getStockCode());
     }
 
     @Transactional
     public void removeFromWatchlist(Long userId, String stockCode) {
+        Instrument instrument = instrumentRepository.findActiveByStockCode(stockCode)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(WatchlistErrorCode.INSTRUMENT_NOT_FOUND));
+
         int deleted = watchlistItemRepository.deleteByUserIdAndStockCode(userId, stockCode);
         if (deleted == 0) {
             throw new BusinessException(WatchlistErrorCode.WATCHLIST_ITEM_NOT_FOUND);
         }
+
+        // 관심종목 삭제 시 연관 가격 알림 제거 및 레지스트리 갱신
+        priceAlertRepository.deleteByUserIdAndInstrumentId(userId, instrument.getInstrumentId());
+        activePriceAlertRegistry.unregister(stockCode);
     }
 
     @Transactional

--- a/src/main/java/com/sollite/websocket/config/StompAuthInterceptor.java
+++ b/src/main/java/com/sollite/websocket/config/StompAuthInterceptor.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -38,15 +39,15 @@ public class StompAuthInterceptor implements ChannelInterceptor {
         if (accessor == null) return message;
 
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-            handleConnect(accessor);
+            handleConnect(message, accessor);
         } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
-            handleSubscribe(accessor);
+            handleSubscribe(message, accessor);
         }
 
         return message;
     }
 
-    private void handleConnect(StompHeaderAccessor accessor) {
+    private void handleConnect(Message<?> message, StompHeaderAccessor accessor) {
         String authHeader = accessor.getFirstNativeHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             log.debug("[STOMP] CONNECT: Authorization 헤더 없음 — 비인증 연결 허용");
@@ -56,7 +57,7 @@ public class StompAuthInterceptor implements ChannelInterceptor {
         String token = authHeader.substring(7);
         if (!jwtTokenProvider.validateToken(token)) {
             log.warn("[STOMP] CONNECT: 유효하지 않은 JWT");
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다");
+            throw new MessageDeliveryException(message, "유효하지 않은 토큰입니다");
         }
 
         Long userId = jwtTokenProvider.getUserIdFromToken(token);
@@ -64,7 +65,7 @@ public class StompAuthInterceptor implements ChannelInterceptor {
         log.debug("[STOMP] CONNECT: userId={} 인증 완료", userId);
     }
 
-    private void handleSubscribe(StompHeaderAccessor accessor) {
+    private void handleSubscribe(Message<?> message, StompHeaderAccessor accessor) {
         String destination = accessor.getDestination();
         if (destination == null || !destination.startsWith(NOTIFICATION_TOPIC_PREFIX)) {
             return; // 알림 토픽이 아니면 검증 생략
@@ -76,7 +77,7 @@ public class StompAuthInterceptor implements ChannelInterceptor {
         if (principal == null || !subscribedUserId.equals(principal.getName())) {
             log.warn("[STOMP] SUBSCRIBE: 알림 구독 권한 없음 - destination={}, principal={}",
                     destination, principal != null ? principal.getName() : "null");
-            throw new IllegalArgumentException("해당 알림 채널에 구독 권한이 없습니다");
+            throw new MessageDeliveryException(message, "해당 알림 채널에 구독 권한이 없습니다");
         }
     }
 }

--- a/src/main/java/com/sollite/websocket/config/StompAuthInterceptor.java
+++ b/src/main/java/com/sollite/websocket/config/StompAuthInterceptor.java
@@ -1,0 +1,82 @@
+package com.sollite.websocket.config;
+
+import com.sollite.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+/**
+ * STOMP 채널 인터셉터.
+ *
+ * CONNECT: Authorization 헤더의 JWT를 검증하여 StompPrincipal(userId)을 세션에 바인딩.
+ * SUBSCRIBE: /topic/notifications/{userId} 구독 시 자신의 userId만 구독 가능하도록 검증.
+ *
+ * 인증 실패 시 예외를 던져 연결/구독을 차단한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompAuthInterceptor implements ChannelInterceptor {
+
+    private static final String NOTIFICATION_TOPIC_PREFIX = "/topic/notifications/";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) return message;
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            handleConnect(accessor);
+        } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            handleSubscribe(accessor);
+        }
+
+        return message;
+    }
+
+    private void handleConnect(StompHeaderAccessor accessor) {
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.debug("[STOMP] CONNECT: Authorization 헤더 없음 — 비인증 연결 허용");
+            return;
+        }
+
+        String token = authHeader.substring(7);
+        if (!jwtTokenProvider.validateToken(token)) {
+            log.warn("[STOMP] CONNECT: 유효하지 않은 JWT");
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다");
+        }
+
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        accessor.setUser(new StompPrincipal(String.valueOf(userId)));
+        log.debug("[STOMP] CONNECT: userId={} 인증 완료", userId);
+    }
+
+    private void handleSubscribe(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (destination == null || !destination.startsWith(NOTIFICATION_TOPIC_PREFIX)) {
+            return; // 알림 토픽이 아니면 검증 생략
+        }
+
+        Principal principal = accessor.getUser();
+        String subscribedUserId = destination.substring(NOTIFICATION_TOPIC_PREFIX.length());
+
+        if (principal == null || !subscribedUserId.equals(principal.getName())) {
+            log.warn("[STOMP] SUBSCRIBE: 알림 구독 권한 없음 - destination={}, principal={}",
+                    destination, principal != null ? principal.getName() : "null");
+            throw new IllegalArgumentException("해당 알림 채널에 구독 권한이 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/sollite/websocket/config/StompPrincipal.java
+++ b/src/main/java/com/sollite/websocket/config/StompPrincipal.java
@@ -1,0 +1,16 @@
+package com.sollite.websocket.config;
+
+import java.security.Principal;
+
+/**
+ * STOMP CONNECT 시 JWT에서 추출한 userId를 담는 Principal 구현체.
+ * StompAuthInterceptor가 생성하여 세션에 바인딩하고,
+ * SUBSCRIBE 단계에서 구독 목적지 검증에 사용된다.
+ */
+public record StompPrincipal(String name) implements Principal {
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/sollite/websocket/service/LsBrokerService.java
+++ b/src/main/java/com/sollite/websocket/service/LsBrokerService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.global.service.LsTokenService;
 import com.sollite.market.domain.repository.InstrumentRepository;
 import com.sollite.notifications.event.PriceChangeEvent;
+import com.sollite.notifications.service.ActivePriceAlertRegistry;
 import com.sollite.order.event.MarketTickEvent;
 import com.sollite.order.service.ActiveOrderRegistry;
 import jakarta.annotation.PostConstruct;
@@ -46,6 +47,7 @@ public class LsBrokerService {
     private final InstrumentRepository instrumentRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ActiveOrderRegistry activeOrderRegistry;
+    private final ActivePriceAlertRegistry activePriceAlertRegistry;
 
     private static final String INDEX_SNAPSHOT_PREFIX = "index:snapshot:";
     private static final Duration INDEX_SNAPSHOT_TTL = Duration.ofHours(48);
@@ -364,7 +366,9 @@ public class LsBrokerService {
                 }
             }
 
-            if ("US3".equals(trCd) || "GSC".equals(trCd)) {
+            // 체결 틱(US3/GSC)이고 활성 가격 알림이 있는 종목일 때만 가격 변동 이벤트 발행
+            if (("US3".equals(trCd) || "GSC".equals(trCd))
+                    && activePriceAlertRegistry.hasActiveAlerts(symbol)) {
                 java.math.BigDecimal tickPrice = extractTradePrice(trCd, body);
                 if (tickPrice != null) {
                     applicationEventPublisher.publishEvent(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,6 +115,16 @@ logging:
     reactor.netty: WARN
 
 
+# ── Actuator ──
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics
+  endpoint:
+    health:
+      show-details: never
+
 # ── LS Securities API  & Websocket ──
 ls:
   api:


### PR DESCRIPTION
## 연관된 이슈
* Closes #53

## 작업 내용

### 알림 도메인 구현
- `Notification`, `NotificationSetting`, `PriceAlert` Entity 및 Repository
- `NotificationType(EXECUTION, PRICE_ALERT)` Enum
- 알림 목록/미읽은 수 조회, 단건/전체 읽음 처리 API
- 가격 알림 목록 조회 API
- 알림 설정 조회/수정 API (가격·체결 알림 유형별 토글, 변동률 기준)

### 실시간 알림 처리
- `ExecutionNotificationListener`: 체결 이벤트 수신 → `@TransactionalEventListener(AFTER_COMMIT)` + `@Async`로 알림 생성
- `PriceAlertChecker`: 가격 변동 이벤트 수신 → 사용자별 조건 평가 → `PriceAlertTriggeredEvent` 발행
- `PriceAlertNotificationListener`: outer 트랜잭션 커밋 후에만 알림 발송하여 중복 발송 방지
- `NotificationService.createAndSend`: `REQUIRES_NEW` 트랜잭션 + `afterCommit` WebSocket 전송

### STOMP WebSocket 인증
- `StompAuthInterceptor`: CONNECT 프레임 JWT 검증 및 Principal 설정
- `StompPrincipal`: STOMP 세션 사용자 식별용 Principal 구현체

### 스레드풀 구조 개선
- `priceCheckExecutor` 분리 (Core 2, Max 4, Queue 1000): `PriceAlertChecker` 전용
- `notificationExecutor`를 체결·가격 알림 발송 전용으로 격리하여 큐 포화 시 유실 방지
- `ActivePriceAlertRegistry`: 활성 가격 알림 종목을 인메모리 카운터로 관리, `LsBrokerService`에서 발행 전 필터링으로 불필요한 이벤트 제거
- 기존 `ActiveOrderRegistry` 패턴을 동일하게 적용

### 동시성 및 성능
- `findActiveByInstrumentIdsWithLock`: `PESSIMISTIC_WRITE`로 중복 트리거 방지
- `NotificationSettingRepository.findByUserIdWithLock`: 알림 설정 동시 수정 race condition 방지
- `NotificationSettingService`: `@Cacheable`로 틱마다 DB 조회 최소화 (TTL 1분)
- `PriceAlert` 생성자: `PRICE + BOTH` 조합 유효성 검증

## 체크리스트
- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항
- 등락률 알림(`PERCENT` 타입) 특성상 장중 실시간 틱에서만 동작하여 테스트 환경에서 조건 재현이 어렵습니다. `PriceAlertChecker.checkPercentTrigger()` 로직 및 `isTriggerConditionMet()` 분기 검토 부탁드립니다.
- `priceCheckExecutor`와 `orderMatchingExecutor`가 `HikariCP maximum-pool-size: 5`를 공유하는 구조입니다. 두 기능이 동시에 최대 부하일 경우 커넥션 경쟁이 발생할 수 있어 풀 크기 상향 검토가 필요합니다.

