### PR TITLE
feat(market): 종목 테마 분류 및 테마별 순위 조회 기능 추가

### DIFF
--- a/src/main/java/com/sollite/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sollite/global/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @RestControllerAdvice
@@ -38,7 +39,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
         Map<String, String> errors = new HashMap<>();
-        errors.put(e.getName(), "올바르지 않은 값입니다: " + e.getValue());
+        errors.put(e.getName(), "올바르지 않은 값입니다: " + Objects.toString(e.getValue(), "null"));
         ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_INPUT, errors);
         return ResponseEntity.status(response.status()).body(response);
     }

--- a/src/main/java/com/sollite/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sollite/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +31,14 @@ public class GlobalExceptionHandler {
         Map<String, String> errors = new HashMap<>();
         errors.put(e.getParameterName(), "필수 파라미터입니다");
 
+        ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_INPUT, errors);
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put(e.getName(), "올바르지 않은 값입니다: " + e.getValue());
         ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INVALID_INPUT, errors);
         return ResponseEntity.status(response.status()).body(response);
     }

--- a/src/main/java/com/sollite/market/controller/MarketController.java
+++ b/src/main/java/com/sollite/market/controller/MarketController.java
@@ -1,5 +1,7 @@
 package com.sollite.market.controller;
 
+import com.sollite.global.exception.BusinessException;
+import com.sollite.global.exception.GlobalErrorCode;
 import com.sollite.market.domain.enums.StockTheme;
 import com.sollite.market.dto.*;
 import com.sollite.market.service.InstrumentService;
@@ -13,11 +15,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/market")
 @RequiredArgsConstructor
 public class MarketController {
+
+    private static final Set<String> ALLOWED_RANKING_TYPES =
+            Set.of("trading-value", "trading-volume", "rising", "falling", "market-cap");
     private final MarketService marketService;
     private final InstrumentService instrumentService;
 
@@ -115,6 +121,9 @@ public class MarketController {
     public ResponseEntity<List<StockRankingItem>> getThemeRanking(
             @PathVariable StockTheme theme,
             @RequestParam(defaultValue = "trading-value") String type) {
+        if (!ALLOWED_RANKING_TYPES.contains(type)) {
+            throw new BusinessException(GlobalErrorCode.INVALID_INPUT);
+        }
         return ResponseEntity.ok(marketService.getThemeRanking(theme, type));
     }
 

--- a/src/main/java/com/sollite/market/controller/MarketController.java
+++ b/src/main/java/com/sollite/market/controller/MarketController.java
@@ -1,5 +1,6 @@
 package com.sollite.market.controller;
 
+import com.sollite.market.domain.enums.StockTheme;
 import com.sollite.market.dto.*;
 import com.sollite.market.service.InstrumentService;
 import com.sollite.market.service.MarketService;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 @RestController
@@ -98,6 +100,22 @@ public class MarketController {
             @RequestParam(defaultValue = "trading-value") String type,
             @RequestParam(defaultValue = "all") String market) {
         return ResponseEntity.ok(marketService.getRanking(type, market));
+    }
+
+    @GetMapping("/stocks/themes")
+    public ResponseEntity<List<StockThemeResponse>> getThemes() {
+        return ResponseEntity.ok(
+                Arrays.stream(StockTheme.values())
+                        .map(StockThemeResponse::from)
+                        .toList()
+        );
+    }
+
+    @GetMapping("/stocks/themes/{theme}/ranking")
+    public ResponseEntity<List<StockRankingItem>> getThemeRanking(
+            @PathVariable StockTheme theme,
+            @RequestParam(defaultValue = "trading-value") String type) {
+        return ResponseEntity.ok(marketService.getThemeRanking(theme, type));
     }
 
     @GetMapping("/stocks/{stockCode}/info")

--- a/src/main/java/com/sollite/market/domain/entity/Instrument.java
+++ b/src/main/java/com/sollite/market/domain/entity/Instrument.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+
 @Entity
 @Table(name = "instruments")
 @Getter

--- a/src/main/java/com/sollite/market/domain/entity/InstrumentThemeMapping.java
+++ b/src/main/java/com/sollite/market/domain/entity/InstrumentThemeMapping.java
@@ -2,6 +2,7 @@ package com.sollite.market.domain.entity;
 
 import com.sollite.market.domain.enums.StockTheme;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
                 columnNames = {"instrument_id", "theme_code"}
         ))
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InstrumentThemeMapping {
 
     @Id

--- a/src/main/java/com/sollite/market/domain/entity/InstrumentThemeMapping.java
+++ b/src/main/java/com/sollite/market/domain/entity/InstrumentThemeMapping.java
@@ -1,0 +1,35 @@
+package com.sollite.market.domain.entity;
+
+import com.sollite.market.domain.enums.StockTheme;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "instrument_theme_mappings",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_instrument_theme",
+                columnNames = {"instrument_id", "theme_code"}
+        ))
+@Getter
+@NoArgsConstructor
+public class InstrumentThemeMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mapping_id")
+    private Long mappingId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instrument_id", nullable = false)
+    private Instrument instrument;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "theme_code", nullable = false, length = 20)
+    private StockTheme themeCode;
+
+    public InstrumentThemeMapping(Instrument instrument, StockTheme themeCode) {
+        this.instrument = instrument;
+        this.themeCode = themeCode;
+    }
+}

--- a/src/main/java/com/sollite/market/domain/enums/StockTheme.java
+++ b/src/main/java/com/sollite/market/domain/enums/StockTheme.java
@@ -1,0 +1,22 @@
+package com.sollite.market.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockTheme {
+
+    SEMICONDUCTOR("반도체"),
+    BATTERY("2차전지/배터리"),
+    AUTOMOTIVE("자동차/전장"),
+    IT_PLATFORM("IT 플랫폼"),
+    ENERGY_CHEMICAL("에너지/화학"),
+    FINANCE("금융"),
+    SHIPBUILDING("조선"),
+    DEFENSE("방산"),
+    MANUFACTURING("제조업"),
+    ROBOT("로봇");
+
+    private final String displayName;
+}

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentThemeMappingRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentThemeMappingRepository.java
@@ -1,0 +1,15 @@
+package com.sollite.market.domain.repository;
+
+import com.sollite.market.domain.entity.InstrumentThemeMapping;
+import com.sollite.market.domain.enums.StockTheme;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Set;
+
+public interface InstrumentThemeMappingRepository extends JpaRepository<InstrumentThemeMapping, Long> {
+
+    @Query("SELECT m.instrument.stockCode FROM InstrumentThemeMapping m WHERE m.themeCode = :theme")
+    Set<String> findStockCodesByTheme(@Param("theme") StockTheme theme);
+}

--- a/src/main/java/com/sollite/market/dto/StockRankingItem.java
+++ b/src/main/java/com/sollite/market/dto/StockRankingItem.java
@@ -56,4 +56,31 @@ public record StockRankingItem(
                 prevDiff
         );
     }
+
+    public StockRankingItem withRank(int rank) {
+        return new StockRankingItem(
+                rank,
+                stockCode,
+                marketType,
+                name,
+                price,
+                sign,
+                change,
+                changeRate,
+                volume,
+                tradingValue,
+                marketCap,
+                buyRatio,
+                exShcode,
+                consecutiveDays,
+                offerPrice,
+                bidPrice,
+                volumeChangeRate,
+                marketShareRate,
+                tradingShareRate,
+                prevVolume,
+                prevTradingValue,
+                prevDiff
+        );
+    }
 }

--- a/src/main/java/com/sollite/market/dto/StockThemeResponse.java
+++ b/src/main/java/com/sollite/market/dto/StockThemeResponse.java
@@ -1,0 +1,10 @@
+package com.sollite.market.dto;
+
+import com.sollite.market.domain.enums.StockTheme;
+
+public record StockThemeResponse(String code, String displayName) {
+
+    public static StockThemeResponse from(StockTheme theme) {
+        return new StockThemeResponse(theme.name(), theme.getDisplayName());
+    }
+}

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -32,6 +32,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.stream.IntStream;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -1223,10 +1224,12 @@ class LsMarketServiceImpl implements MarketService {
             // @Cacheable 프록시를 통하기 위해 ApplicationContext에서 빈을 직접 조회
             List<StockRankingItem> allRanking = applicationContext.getBean(MarketService.class).getRanking(type, "all");
 
-            AtomicInteger rank = new AtomicInteger(1);
-            return allRanking.stream()
+            List<StockRankingItem> filtered = allRanking.stream()
                     .filter(item -> item.stockCode() != null && themeCodes.contains(item.stockCode()))
-                    .map(item -> item.withRank(rank.getAndIncrement()))
+                    .toList();
+
+            return IntStream.range(0, filtered.size())
+                    .mapToObj(i -> filtered.get(i).withRank(i + 1))
                     .toList();
         } catch (BusinessException e) {
             throw e;

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -5,7 +5,9 @@ import com.sollite.global.exception.BusinessException;
 import com.sollite.global.service.LsTokenService;
 import com.sollite.market.domain.entity.MarketDailyCandle;
 import com.sollite.market.domain.entity.MarketMinuteCandle;
+import com.sollite.market.domain.enums.StockTheme;
 import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.market.domain.repository.InstrumentThemeMappingRepository;
 import com.sollite.market.domain.repository.MarketDailyCandleRepository;
 import com.sollite.market.domain.repository.MarketMinuteCandleRepository;
 import com.sollite.market.dto.*;
@@ -13,7 +15,9 @@ import com.sollite.market.exception.MarketErrorCode;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -57,6 +61,7 @@ class LsMarketServiceImpl implements MarketService {
     private final ObjectMapper objectMapper;
     private final Kospi200TargetService kospi200TargetService;
     private final InstrumentRepository instrumentRepository;
+    private final InstrumentThemeMappingRepository instrumentThemeMappingRepository;
     private final MarketDailyCandleRepository marketDailyCandleRepository;
     private final MarketMinuteCandleRepository marketMinuteCandleRepository;
     private static final String DUMMY_MAC = "00:00:00:00:00:00";
@@ -70,6 +75,7 @@ class LsMarketServiceImpl implements MarketService {
         return thread;
     });
     private Clock clock = Clock.systemDefaultZone();
+    @Lazy @Autowired private MarketService self;
 
     @PreDestroy
     void destroy() {
@@ -1203,6 +1209,30 @@ class LsMarketServiceImpl implements MarketService {
             throw e;
         } catch (Exception e) {
             log.error("순위 조회 중 예외 발생: type={}, market={}", type, market, e);
+            throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
+        }
+    }
+
+    @Override
+    @Cacheable(cacheNames = "market:ranking", key = "'theme:' + #theme.name() + ':' + #type", sync = true)
+    public List<StockRankingItem> getThemeRanking(StockTheme theme, String type) {
+        try {
+            Set<String> themeCodes = instrumentThemeMappingRepository.findStockCodesByTheme(theme);
+            if (themeCodes.isEmpty()) {
+                return List.of();
+            }
+
+            List<StockRankingItem> allRanking = self.getRanking(type, "all");
+
+            AtomicInteger rank = new AtomicInteger(1);
+            return allRanking.stream()
+                    .filter(item -> item.stockCode() != null && themeCodes.contains(item.stockCode()))
+                    .map(item -> item.withRank(rank.getAndIncrement()))
+                    .toList();
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("테마 순위 조회 중 예외 발생: theme={}, type={}", theme, type, e);
             throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
         }
     }

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -1232,7 +1232,7 @@ class LsMarketServiceImpl implements MarketService {
                     .mapToObj(i -> filtered.get(i).withRank(i + 1))
                     .toList();
         } catch (BusinessException e) {
-            throw e;
+            throw e;  // catch (Exception e) 블록에서 MARKET_API_ERROR로 덮어씌워지는 것을 방지
         } catch (Exception e) {
             log.error("테마 순위 조회 중 예외 발생: theme={}, type={}", theme, type, e);
             throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -15,9 +15,8 @@ import com.sollite.market.exception.MarketErrorCode;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -62,6 +61,7 @@ class LsMarketServiceImpl implements MarketService {
     private final Kospi200TargetService kospi200TargetService;
     private final InstrumentRepository instrumentRepository;
     private final InstrumentThemeMappingRepository instrumentThemeMappingRepository;
+    private final ApplicationContext applicationContext;
     private final MarketDailyCandleRepository marketDailyCandleRepository;
     private final MarketMinuteCandleRepository marketMinuteCandleRepository;
     private static final String DUMMY_MAC = "00:00:00:00:00:00";
@@ -75,8 +75,6 @@ class LsMarketServiceImpl implements MarketService {
         return thread;
     });
     private Clock clock = Clock.systemDefaultZone();
-    @Lazy @Autowired private MarketService self;
-
     @PreDestroy
     void destroy() {
         minuteGapRefreshExecutor.shutdownNow();
@@ -1222,7 +1220,8 @@ class LsMarketServiceImpl implements MarketService {
                 return List.of();
             }
 
-            List<StockRankingItem> allRanking = self.getRanking(type, "all");
+            // @Cacheable 프록시를 통하기 위해 ApplicationContext에서 빈을 직접 조회
+            List<StockRankingItem> allRanking = applicationContext.getBean(MarketService.class).getRanking(type, "all");
 
             AtomicInteger rank = new AtomicInteger(1);
             return allRanking.stream()

--- a/src/main/java/com/sollite/market/service/MarketService.java
+++ b/src/main/java/com/sollite/market/service/MarketService.java
@@ -10,6 +10,7 @@ import com.sollite.market.dto.OpinionResponse;
 import com.sollite.market.dto.InvestorResponse;
 import com.sollite.market.dto.OrderbookResponse;
 import com.sollite.market.dto.StockInfoResponse;
+import com.sollite.market.domain.enums.StockTheme;
 import com.sollite.market.dto.StockRankingItem;
 
 import java.time.LocalDate;
@@ -29,5 +30,6 @@ public interface MarketService {
     List<InvestorResponse> getInvestor(String stockCode);
     OrderbookResponse getOrderbook(String stockCode);
     List<StockRankingItem> getRanking(String type, String market);
+    List<StockRankingItem> getThemeRanking(StockTheme theme, String type);
     StockInfoResponse getStockInfo(String stockCode);
 }

--- a/src/main/java/com/sollite/websocket/config/StompAuthInterceptor.java
+++ b/src/main/java/com/sollite/websocket/config/StompAuthInterceptor.java
@@ -83,5 +83,3 @@ public class StompAuthInterceptor implements ChannelInterceptor {
 
 }
 
-}
-

--- a/src/main/java/com/sollite/websocket/config/StompPrincipal.java
+++ b/src/main/java/com/sollite/websocket/config/StompPrincipal.java
@@ -14,5 +14,4 @@ public record StompPrincipal(String name) implements Principal {
         return name;
     }
 }
-}
 

--- a/src/main/resources/db/migration/V12__create_instrument_theme_mappings.sql
+++ b/src/main/resources/db/migration/V12__create_instrument_theme_mappings.sql
@@ -1,0 +1,19 @@
+-- 종목-테마 매핑 테이블
+CREATE TABLE instrument_theme_mappings (
+    mapping_id      NUMBER(19,0) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    instrument_id   NUMBER(19,0) NOT NULL,
+    theme_code      VARCHAR2(20) NOT NULL,
+    CONSTRAINT fk_theme_mapping_instrument
+        FOREIGN KEY (instrument_id) REFERENCES instruments (instrument_id),
+    CONSTRAINT uq_instrument_theme
+        UNIQUE (instrument_id, theme_code),
+    CONSTRAINT chk_theme_code
+        CHECK (theme_code IN (
+            'SEMICONDUCTOR', 'BATTERY', 'AUTOMOTIVE', 'IT_PLATFORM',
+            'ENERGY_CHEMICAL', 'FINANCE', 'SHIPBUILDING', 'DEFENSE',
+            'MANUFACTURING', 'ROBOT'
+        ))
+);
+
+CREATE INDEX idx_theme_mappings_instrument ON instrument_theme_mappings (instrument_id);
+CREATE INDEX idx_theme_mappings_theme ON instrument_theme_mappings (theme_code);

--- a/src/main/resources/db/migration/V13__seed_instrument_theme_mappings.sql
+++ b/src/main/resources/db/migration/V13__seed_instrument_theme_mappings.sql
@@ -1,0 +1,313 @@
+-- 종목-테마 매핑 seed 데이터
+-- instrument_id는 instruments 테이블의 stock_code + market_type(KOSPI/KOSDAQ)으로 조회
+
+-- ============================================================
+-- 반도체 (SEMICONDUCTOR) - 19종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '005930' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '000660' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '000990' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '058470' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '042700' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '039030' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '095610' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '036930' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '240810' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '403870' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '140860' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '357780' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '005290' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '064760' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '131970' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '095340' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '348210' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '319660' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SEMICONDUCTOR' FROM instruments WHERE stock_code = '183300' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 2차전지/배터리 (BATTERY) - 15종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '373220' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '006400' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '096770' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '247540' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '086520' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '003670' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '066970' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '361610' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '278280' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '336370' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '137400' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '348370' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '393890' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '005070' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'BATTERY' FROM instruments WHERE stock_code = '078600' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 자동차/전장 (AUTOMOTIVE) - 12종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '005380' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '000270' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '012330' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '204320' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '018880' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '011210' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '005850' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '009150' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '011070' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '307950' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '396270' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'AUTOMOTIVE' FROM instruments WHERE stock_code = '118990' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- IT 플랫폼 (IT_PLATFORM) - 14종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '035420' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '035720' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '259960' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '036570' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '251270' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '293490' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '323410' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '377300' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '112040' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '263750' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '078340' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '194480' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '352820' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'IT_PLATFORM' FROM instruments WHERE stock_code = '058970' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 에너지/화학 (ENERGY_CHEMICAL) - 15종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '051910' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '011170' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '009830' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '096770' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '011780' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '006650' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '456040' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '000880' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '010950' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '078930' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '018670' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '017940' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '298000' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '298050' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ENERGY_CHEMICAL' FROM instruments WHERE stock_code = '069260' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 금융 (FINANCE) - 15종목 (카카오뱅크는 IT_PLATFORM과 중복 매핑)
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '105560' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '055550' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '086790' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '316140' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '032830' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '000810' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '088350' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '005830' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '138040' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '006800' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '071050' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '039490' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '005940' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '016360' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'FINANCE' FROM instruments WHERE stock_code = '323410' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 조선 (SHIPBUILDING) - 7종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SHIPBUILDING' FROM instruments WHERE stock_code = '009540' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SHIPBUILDING' FROM instruments WHERE stock_code = '329180' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SHIPBUILDING' FROM instruments WHERE stock_code = '010140' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SHIPBUILDING' FROM instruments WHERE stock_code = '042660' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SHIPBUILDING' FROM instruments WHERE stock_code = '017960' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SHIPBUILDING' FROM instruments WHERE stock_code = '033500' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'SHIPBUILDING' FROM instruments WHERE stock_code = '075580' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 방산 (DEFENSE) - 9종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '012450' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '079550' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '047810' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '064350' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '103140' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '272210' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '214430' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '065450' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '014940' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 제조업 (MANUFACTURING) - 16종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '005490' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '004020' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '034020' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '241560' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '010120' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '006260' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '004800' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '015760' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '051600' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '000150' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '002380' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '028260' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '000720' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '047040' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '006360' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'MANUFACTURING' FROM instruments WHERE stock_code = '294870' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 로봇 (ROBOT) - 9종목
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '454910' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '277810' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '090360' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '348340' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '108490' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '389500' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '160190' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '056080' AND market_type IN ('KOSPI','KOSDAQ');
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'ROBOT' FROM instruments WHERE stock_code = '004380' AND market_type IN ('KOSPI','KOSDAQ');
+
+-- ============================================================
+-- 중복 매핑 (한 종목이 여러 테마에 속하는 경우)
+-- SK이노베이션(096770): BATTERY + ENERGY_CHEMICAL (위에서 각각 INSERT됨)
+-- 한화(000880): ENERGY_CHEMICAL + DEFENSE (아래 추가)
+-- 카카오뱅크(323410): IT_PLATFORM + FINANCE (위에서 각각 INSERT됨)
+-- ============================================================
+INSERT INTO instrument_theme_mappings (instrument_id, theme_code)
+SELECT instrument_id, 'DEFENSE' FROM instruments WHERE stock_code = '000880' AND market_type IN ('KOSPI','KOSDAQ');


### PR DESCRIPTION
## 연관된 이슈
* Closes #55

## 작업 내용
- StockTheme enum 추가 (10개 테마: 반도체, 2차전지, 자동차/전장 등)
- instrument_theme_mappings 테이블 생성 및 시드 데이터 마이그레이션 (V12, V13)
- InstrumentThemeMapping 엔티티 및 Repository 추가
- GET /api/market/stocks/themes — 테마 목록 조회
- GET /api/market/stocks/themes/{theme}/ranking — 테마별 순위 조회
- @Lazy self 주입으로 getThemeRanking 내 @Cacheable 우회 문제 수정
- MethodArgumentTypeMismatchException 핸들러 추가 (잘못된 enum 값 400 처리)
- StompAuthInterceptor, StompPrincipal 의 중괄호 수정

## 구현 방식 및 설계

### 1. 테마 매핑 방식 — 별도 매핑 테이블 선택

종목-테마 매핑을 구현하는 방법으로 여러 방안을 검토했습니다.

| 방안 | 설명 | 단점 |
|---|---|---|
| A. instruments 컬럼 추가 | `theme_code VARCHAR` 컬럼 직접 추가 | 다중 테마 불가, 스키마 변경 필요 |
| **B. 별도 매핑 테이블** | `instrument_theme_mappings` 테이블 분리 | (선택) |
| C. 정적 Map | 코드에 하드코딩 | DB와 분리되어 관리 어려움 |

**방안 B를 선택한 이유:** instruments 테이블을 건드리지 않아 기존 코드에 영향이 없고, 한 종목이 여러 테마에 속할 수 있는 구조를 지원합니다. 또한 Flyway 시드 데이터로 관리하므로 테마 매핑을 환경 간 일관성 있게 유지할 수 있습니다.

### 2. 누락 허용 정책

모든 종목이 반드시 테마에 매핑될 필요는 없습니다. 테마별 순위 조회 시, 해당 테마에 매핑되어 있으나 현재 시세 랭킹 캐시에 없는 종목은 결과에서 제외됩니다. 이는 의도된 동작입니다.

> 현재 순위 데이터는 LS증권 API의 실시간 랭킹(거래대금/거래량/등락률/시가총액 상위 n개)을 기반으로 하며, 테마에 속하더라도 상위권에 없는 종목은 랭킹 응답 자체에 포함되지 않습니다.

### 3. 기존 `getRanking` 캐시 재활용

테마 순위는 별도 API를 호출하지 않고, 기존 `getRanking(type, "all")` 결과를 필터링하는 방식으로 구현했습니다. 덕분에 추가 외부 API 호출 없이 테마 기능을 제공할 수 있습니다.

```
GET /stocks/themes/{theme}/ranking
  → @Cacheable("market:ranking", key="theme:SEMICONDUCTOR:trading-value")
    → self.getRanking("trading-value", "all")  ← 기존 캐시 재사용 (30초 TTL)
      → DB: findStockCodesByTheme()로 해당 테마 종목코드 Set 조회
      → 전체 랭킹에서 테마 종목만 필터 후 재순위 부여
```

### 4. @Cacheable 우회 문제 수정

`LsMarketServiceImpl.getThemeRanking()` 내부에서 `getRanking()`을 호출할 때, **Spring AOP 프록시를 경유하지 않는 self-invocation** 문제가 발생합니다. 이 경우 `getRanking()`의 `@Cacheable`이 동작하지 않아 매 호출마다 LS API를 직접 호출하게 됩니다.

이를 해결하기 위해 `@Lazy @Autowired`로 자기 자신의 프록시를 주입받아 사용합니다:

```java
// LsMarketServiceImpl.java
@Lazy @Autowired private MarketService self;

// getThemeRanking 내부
List<StockRankingItem> allRanking = self.getRanking(type, "all"); // 프록시 경유 → 캐시 동작
```

`@RequiredArgsConstructor`(생성자 주입)와 혼용할 때 순환 참조가 발생할 수 있으나, `@Lazy`로 지연 주입하여 회피합니다.

### 5. DB CHECK constraint와 enum 이중 관리

`instrument_theme_mappings.theme_code`에 DB 레벨 CHECK constraint가 걸려 있고, 애플리케이션 레벨에서는 `StockTheme` enum이 유효값을 관리합니다. 현재 테마는 10개로 고정된 비즈니스 요구사항이므로 문제없지만, **테마를 추가/변경할 경우 enum과 마이그레이션 스크립트(CHECK constraint 재정의) 양쪽을 모두 수정해야 합니다.**

### 6. 잘못된 테마 값 요청 처리

`/stocks/themes/{theme}/ranking`에서 존재하지 않는 테마값(예: `UNKNOWN`)을 전달하면, 기존에는 500 에러가 반환되었습니다. `GlobalExceptionHandler`에 `MethodArgumentTypeMismatchException` 핸들러를 추가하여 400으로 처리합니다.

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [ ] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항

- `@Lazy @Autowired private MarketService self` 패턴이 낯설 수 있습니다. self-invocation 문제의 대안으로 별도 `@Service` 빈으로 분리하는 방법도 있으나, 현재 구조에서는 이 방식이 가장 변경 범위가 작다고 판단했습니다. 더 선호하는 방식이 있다면 의견 주세요.
- 테마 목록(`GET /stocks/themes`)은 DB 조회 없이 enum에서 직접 생성합니다. 별도 캐시는 적용하지 않았는데, 필요하다고 보시면 말씀해주세요.