### PR TITLE
fix: USD/KRW 환율 조회 폴백 및 해외주식 분차트 sdate 수정

### DIFF
--- a/src/main/java/com/sollite/balance/service/PriceLookupService.java
+++ b/src/main/java/com/sollite/balance/service/PriceLookupService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.balance.dto.PriceQuote;
 import com.sollite.foreignmarket.service.ForeignStockMarketService;
+import com.sollite.index.service.IndexService;
 import com.sollite.market.service.MarketService;
 import com.sollite.websocket.service.LsBrokerService;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class PriceLookupService {
     private final LsBrokerService lsBrokerService;
     private final MarketService marketService;
     private final ForeignStockMarketService foreignStockMarketService;
+    private final IndexService indexService;
     private final ObjectMapper objectMapper;
     private final StringRedisTemplate redisTemplate;
 
@@ -120,9 +122,21 @@ public class PriceLookupService {
 
     // ── 환율 ──────────────────────────────────────────────────────────────────
 
-    /** USD/KRW 환율 조회 (1 USD = X KRW). WS lastValue → Redis snapshot 순으로 폴백. */
+    /** USD/KRW 환율 조회 (1 USD = X KRW). WS lastValue → Redis snapshot → indices 캐시 순으로 폴백. */
     public BigDecimal resolveUsdKrwRate() {
-        return parsePriceFromLastValue("/topic/currency/USD");
+        BigDecimal rate = parsePriceFromLastValue("/topic/currency/USD");
+        if (isValidPrice(rate)) return rate;
+
+        try {
+            return indexService.getIndices().stream()
+                    .filter(i -> "USD".equals(i.code()) && i.price() != null && i.price() > 0)
+                    .map(i -> BigDecimal.valueOf(i.price()))
+                    .findFirst()
+                    .orElse(null);
+        } catch (Exception e) {
+            log.warn("[PriceLookup] indices 캐시 환율 폴백 실패", e);
+            return null;
+        }
     }
 
     // ── 내부 ──────────────────────────────────────────────────────────────────

--- a/src/main/java/com/sollite/foreignmarket/service/LsForeignStockMarketServiceImpl.java
+++ b/src/main/java/com/sollite/foreignmarket/service/LsForeignStockMarketServiceImpl.java
@@ -588,7 +588,10 @@ class LsForeignStockMarketServiceImpl implements ForeignStockMarketService {
             String keysymbol,
             int nmin
     ) throws Exception {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("America/New_York"));
+        LocalDate sdate = today.getDayOfWeek() == java.time.DayOfWeek.SATURDAY ? today.minusDays(1)
+                : today.getDayOfWeek() == java.time.DayOfWeek.SUNDAY ? today.minusDays(2)
+                : today;
         Map<LocalDateTime, LsG3203Res.G3203OutBlock1> deduplicated = new LinkedHashMap<>();
         String ctsDate = "";
         String ctsTime = "";
@@ -608,7 +611,7 @@ class LsForeignStockMarketServiceImpl implements ForeignStockMarketService {
                             nmin,
                             DEFAULT_NON_COMPRESSED_CHART_QRYCNT,
                             COMPRESSED_NO,
-                            today.minusDays(7).format(DATE_FMT),
+                            sdate.format(DATE_FMT),
                             "",
                             ctsDate,
                             ctsTime

--- a/src/main/java/com/sollite/foreignmarket/service/LsForeignStockMarketServiceImpl.java
+++ b/src/main/java/com/sollite/foreignmarket/service/LsForeignStockMarketServiceImpl.java
@@ -15,9 +15,11 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -589,8 +591,9 @@ class LsForeignStockMarketServiceImpl implements ForeignStockMarketService {
             int nmin
     ) throws Exception {
         LocalDate today = LocalDate.now(ZoneId.of("America/New_York"));
-        LocalDate sdate = today.getDayOfWeek() == java.time.DayOfWeek.SATURDAY ? today.minusDays(1)
-                : today.getDayOfWeek() == java.time.DayOfWeek.SUNDAY ? today.minusDays(2)
+        DayOfWeek dow = today.getDayOfWeek();
+        LocalDate sdate = dow == DayOfWeek.SATURDAY ? today.minusDays(1)
+                : dow == DayOfWeek.SUNDAY ? today.minusDays(2)
                 : today;
         Map<LocalDateTime, LsG3203Res.G3203OutBlock1> deduplicated = new LinkedHashMap<>();
         String ctsDate = "";

--- a/src/main/java/com/sollite/index/service/LsIndexServiceImpl.java
+++ b/src/main/java/com/sollite/index/service/LsIndexServiceImpl.java
@@ -47,7 +47,8 @@ class LsIndexServiceImpl implements IndexService {
     );
 
     @Override
-    @Cacheable(cacheNames = "market:indices", key = "'fixed'", sync = true)
+    @Cacheable(cacheNames = "market:indices", key = "'fixed'", sync = true,
+            unless = "#result.?[code == 'USD' && price == null].size() > 0")
     public List<IndexResponse> getIndices() {
         List<IndexResponse> result = new ArrayList<>();
         for (IndexMeta meta : INDICES) {


### PR DESCRIPTION
## 연관된 이슈

없음

## 작업 내용

### 1. USD/KRW 환율 조회 폴백 추가 (`PriceLookupService`, `LsIndexServiceImpl`)
- 주말/장 마감 후 LS WS가 CUR 틱을 보내지 않는 경우, `currency:snapshot:` Redis 키가 없어 `resolveUsdKrwRate()`가 null을 반환하며 `summary`, `overseas`, `portfolio`, `flow` API가 503 오류 발생
- `resolveUsdKrwRate()`에 `indexService.getIndices()` 캐시를 폴백으로 추가하여 WS/snapshot 없이도 환율 조회 가능하도록 수정
- `getIndices()` 캐시에 USD price가 null인 경우 캐시 저장을 건너뛰도록 `unless` 조건 추가 (null-price가 굳는 문제 방지)

### 2. 해외주식 분차트 sdate 주말 폴백 처리 (`LsForeignStockMarketServiceImpl`)
- `fetchMinuteChartPages()`의 `sdate`를 `today.minusDays(7)` → 오늘(NY 기준)로 변경
- 주말(토/일) 진입 시 금요일로 자동 폴백하여 불필요한 80+ API 요청 및 rate limit 문제 해소

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

`resolveUsdKrwRate()` 폴백 체인이 WS lastValue → currency:snapshot → indices 캐시 순서인데, indices 캐시도 없는 경우(앱 첫 시작 + WS 틱 미수신)에는 여전히 503이 발생합니다. 이 엣지케이스는 WS 연결 후 첫 틱 수신 전 짧은 구간에만 해당합니다.