### PR TITLE
feat(layout): 다크모드 테마 설정 API 구현

### DIFF
--- a/src/main/java/com/sollite/user/controller/UserController.java
+++ b/src/main/java/com/sollite/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sollite.user.controller;
 
 import com.sollite.global.util.AuthUtil;
+import com.sollite.user.domain.enums.ThemeType;
 import com.sollite.user.dto.*;
 import com.sollite.user.service.UserService;
 import jakarta.validation.Valid;
@@ -72,14 +73,14 @@ public class UserController {
      *
      * @param authentication 현재 인증된 사용자 정보
      * @param request 변경할 테마 (LIGHT 또는 DARK)
-     * @return 200 OK - 변경 완료 메시지
+     * @return 200 OK - 변경된 테마 값 포함 응답
      */
     @PatchMapping("/theme")
-    public ResponseEntity<MessageResponse> updateTheme(Authentication authentication,
-                                                       @Valid @RequestBody ThemeUpdateRequest request) {
+    public ResponseEntity<ThemeUpdateResponse> updateTheme(Authentication authentication,
+                                                           @Valid @RequestBody ThemeUpdateRequest request) {
         Long userId = AuthUtil.getUserId(authentication);
-        userService.updateTheme(userId, request);
-        return ResponseEntity.ok(new MessageResponse("테마가 변경되었습니다."));
+        ThemeType theme = userService.updateTheme(userId, request);
+        return ResponseEntity.ok(new ThemeUpdateResponse("테마가 변경되었습니다.", theme));
     }
 
 }

--- a/src/main/java/com/sollite/user/controller/UserController.java
+++ b/src/main/java/com/sollite/user/controller/UserController.java
@@ -67,4 +67,19 @@ public class UserController {
         return ResponseEntity.ok(new MessageResponse("비밀번호가 변경되었습니다."));
     }
 
+    /**
+     * 현재 사용자의 화면 테마를 변경합니다.
+     *
+     * @param authentication 현재 인증된 사용자 정보
+     * @param request 변경할 테마 (LIGHT 또는 DARK)
+     * @return 200 OK - 변경 완료 메시지
+     */
+    @PatchMapping("/theme")
+    public ResponseEntity<MessageResponse> updateTheme(Authentication authentication,
+                                                       @Valid @RequestBody ThemeUpdateRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        userService.updateTheme(userId, request);
+        return ResponseEntity.ok(new MessageResponse("테마가 변경되었습니다."));
+    }
+
 }

--- a/src/main/java/com/sollite/user/domain/entity/User.java
+++ b/src/main/java/com/sollite/user/domain/entity/User.java
@@ -106,6 +106,10 @@ public class User {
         if (phone != null) this.phone = phone;
     }
 
+    public void updateTheme(String theme) {
+        this.theme = theme;
+    }
+
     public void withdraw() {
         this.status = UserStatus.WITHDRAWN;
         this.withdrawnAt = LocalDateTime.now();

--- a/src/main/java/com/sollite/user/domain/entity/User.java
+++ b/src/main/java/com/sollite/user/domain/entity/User.java
@@ -1,5 +1,6 @@
 package com.sollite.user.domain.entity;
 
+import com.sollite.user.domain.enums.ThemeType;
 import com.sollite.user.domain.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
@@ -53,8 +54,9 @@ public class User {
     @Column(name = "default_market", length = 10)
     private String defaultMarket = "DOMESTIC";
 
+    @Enumerated(EnumType.STRING)
     @Column(length = 20)
-    private String theme = "LIGHT";
+    private ThemeType theme = ThemeType.LIGHT;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -106,7 +108,7 @@ public class User {
         if (phone != null) this.phone = phone;
     }
 
-    public void updateTheme(String theme) {
+    public void updateTheme(ThemeType theme) {
         this.theme = theme;
     }
 

--- a/src/main/java/com/sollite/user/domain/enums/ThemeType.java
+++ b/src/main/java/com/sollite/user/domain/enums/ThemeType.java
@@ -1,0 +1,5 @@
+package com.sollite.user.domain.enums;
+
+public enum ThemeType {
+    LIGHT, DARK
+}

--- a/src/main/java/com/sollite/user/dto/ThemeUpdateRequest.java
+++ b/src/main/java/com/sollite/user/dto/ThemeUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.sollite.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ThemeUpdateRequest(
+        @NotBlank(message = "테마 값은 비워둘 수 없습니다")
+        @Pattern(
+                regexp = "^(LIGHT|DARK)$",
+                message = "테마는 LIGHT 또는 DARK 이어야 합니다"
+        )
+        String theme
+) {}

--- a/src/main/java/com/sollite/user/dto/ThemeUpdateRequest.java
+++ b/src/main/java/com/sollite/user/dto/ThemeUpdateRequest.java
@@ -1,13 +1,9 @@
 package com.sollite.user.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import com.sollite.user.domain.enums.ThemeType;
+import jakarta.validation.constraints.NotNull;
 
 public record ThemeUpdateRequest(
-        @NotBlank(message = "테마 값은 비워둘 수 없습니다")
-        @Pattern(
-                regexp = "^(LIGHT|DARK)$",
-                message = "테마는 LIGHT 또는 DARK 이어야 합니다"
-        )
-        String theme
+        @NotNull(message = "테마 값은 비워둘 수 없습니다")
+        ThemeType theme
 ) {}

--- a/src/main/java/com/sollite/user/dto/ThemeUpdateResponse.java
+++ b/src/main/java/com/sollite/user/dto/ThemeUpdateResponse.java
@@ -1,0 +1,8 @@
+package com.sollite.user.dto;
+
+import com.sollite.user.domain.enums.ThemeType;
+
+public record ThemeUpdateResponse(
+        String message,
+        ThemeType theme
+) {}

--- a/src/main/java/com/sollite/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/sollite/user/dto/UserProfileResponse.java
@@ -9,5 +9,6 @@ public record UserProfileResponse(
         String phone,
         boolean emailVerified,
         Long accountId,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String theme
 ) {}

--- a/src/main/java/com/sollite/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/sollite/user/dto/UserProfileResponse.java
@@ -1,5 +1,7 @@
 package com.sollite.user.dto;
 
+import com.sollite.user.domain.enums.ThemeType;
+
 import java.time.LocalDateTime;
 
 public record UserProfileResponse(
@@ -10,5 +12,5 @@ public record UserProfileResponse(
         boolean emailVerified,
         Long accountId,
         LocalDateTime createdAt,
-        String theme
+        ThemeType theme
 ) {}

--- a/src/main/java/com/sollite/user/service/UserService.java
+++ b/src/main/java/com/sollite/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.sollite.global.exception.BusinessException;
 import com.sollite.global.security.JwtTokenProvider;
 import com.sollite.user.domain.entity.User;
 import com.sollite.user.domain.entity.UserConsent;
+import com.sollite.user.domain.enums.ThemeType;
 import com.sollite.user.domain.repository.UserConsentRepository;
 import com.sollite.user.domain.repository.UserRepository;
 import com.sollite.user.dto.*;
@@ -408,14 +409,16 @@ public class UserService {
      *
      * @param userId  사용자 ID
      * @param request 변경할 테마 값 (LIGHT 또는 DARK)
+     * @return 변경된 테마 값
      * @throws BusinessException 사용자 미등록 시
      */
     @Transactional
-    public void updateTheme(Long userId, ThemeUpdateRequest request) {
+    public ThemeType updateTheme(Long userId, ThemeUpdateRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         user.updateTheme(request.theme());
+        return user.getTheme();
     }
 
     /**

--- a/src/main/java/com/sollite/user/service/UserService.java
+++ b/src/main/java/com/sollite/user/service/UserService.java
@@ -366,7 +366,8 @@ public class UserService {
                 user.getPhone(),
                 user.isEmailVerified(),
                 accountId,
-                user.getCreatedAt()
+                user.getCreatedAt(),
+                user.getTheme()
         );
     }
 
@@ -397,8 +398,24 @@ public class UserService {
                 user.getPhone(),
                 user.isEmailVerified(),
                 accountId,
-                user.getCreatedAt()
+                user.getCreatedAt(),
+                user.getTheme()
         );
+    }
+
+    /**
+     * 사용자의 화면 테마를 변경합니다.
+     *
+     * @param userId  사용자 ID
+     * @param request 변경할 테마 값 (LIGHT 또는 DARK)
+     * @throws BusinessException 사용자 미등록 시
+     */
+    @Transactional
+    public void updateTheme(Long userId, ThemeUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        user.updateTheme(request.theme());
     }
 
     /**


### PR DESCRIPTION
## 연관된 이슈


## 작업 내용

사용자별 다크모드 테마 설정을 서버에 저장하고 조회하는 API를 구현했습니다.

### 변경 사항

- `User` 엔티티에 `theme` 필드 추가 (기본값: `LIGHT`)
- `GET /api/users/me` 응답에 `theme` 필드 추가
- `PATCH /api/users/me/theme` 엔드포인트 신규 추가
  - 요청값: `LIGHT` 또는 `DARK` (validation 적용)

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [ ] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> 로그인 상태에서 설정 저장하면 계속해서 유지되도록 구현했습니다. 현재 font size와는 저장 방식이 다른데, 통일할 필요가 있을지 논의 필요합니다.