### PR TITLE
fix(balance/index): USD/KRW 환율 조회 개선 및 포트폴리오 스냅샷 스케줄러 추가

### DIFF
--- a/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
+++ b/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
@@ -1,9 +1,11 @@
 package com.sollite.account.domain.repository;
 
 import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.AccountStatus;
 import com.sollite.account.domain.enums.RoundStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -18,9 +20,11 @@ public interface SimulationRoundRepository extends JpaRepository<SimulationRound
             from SimulationRound sr
             join fetch sr.account a
             where sr.roundStatus = :roundStatus
-              and a.accountStatus = com.sollite.account.domain.enums.AccountStatus.ACTIVE
+              and a.accountStatus = :accountStatus
             """)
-    List<SimulationRound> findAllActiveWithAccountByRoundStatus(RoundStatus roundStatus);
+    List<SimulationRound> findAllActiveWithAccountByRoundStatus(
+            @Param("roundStatus") RoundStatus roundStatus,
+            @Param("accountStatus") AccountStatus accountStatus);
 
     @Transactional
     void deleteByAccount_AccountId(Long accountId);

--- a/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
+++ b/src/main/java/com/sollite/account/domain/repository/SimulationRoundRepository.java
@@ -3,13 +3,24 @@ package com.sollite.account.domain.repository;
 import com.sollite.account.domain.entity.SimulationRound;
 import com.sollite.account.domain.enums.RoundStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SimulationRoundRepository extends JpaRepository<SimulationRound, Long> {
 
     Optional<SimulationRound> findByAccount_AccountIdAndRoundStatus(Long accountId, RoundStatus roundStatus);
+
+    @Query("""
+            select sr
+            from SimulationRound sr
+            join fetch sr.account a
+            where sr.roundStatus = :roundStatus
+              and a.accountStatus = com.sollite.account.domain.enums.AccountStatus.ACTIVE
+            """)
+    List<SimulationRound> findAllActiveWithAccountByRoundStatus(RoundStatus roundStatus);
 
     @Transactional
     void deleteByAccount_AccountId(Long accountId);

--- a/src/main/java/com/sollite/balance/service/BalanceService.java
+++ b/src/main/java/com/sollite/balance/service/BalanceService.java
@@ -227,7 +227,7 @@ public class BalanceService {
                                 h.getInstrument().getStockCode(),
                                 toForeignExchcd(h.getInstrument().getExchangeCode()))))
                 .toList());
-        BigDecimal usdKrwRate = resolveUsdKrwRate();
+        BigDecimal usdKrwRate = resolveUsdKrwDisplayRate();
 
         return holdings.stream()
                 .map(h -> HoldingResponse.from(h, prices.get(h.getInstrument().getInstrumentId()), usdKrwRate))
@@ -315,6 +315,21 @@ public class BalanceService {
     }
 
     /**
+     * 스케줄러/배치에서 활성 라운드의 일일 스냅샷을 적재한다.
+     */
+    public void captureDailySnapshot(Account account, SimulationRound round) {
+        ValuationSummary valuation = calculateValuation(new AccountRound(account, round));
+        portfolioSnapshotService.upsertTodaySnapshot(
+                account,
+                round,
+                valuation.totalAssets(),
+                valuation.cashKrwAmount(),
+                valuation.cashUsdAmount(),
+                valuation.usdKrwRate(),
+                valuation.totalStockEvaluation());
+    }
+
+    /**
      * 포트폴리오 파이차트 구성 비중 — 현재가 기반 실시간 평가 (모든 금액 KRW 기준)
      * 현금은 KRW/USD 각각 아이템으로 분리 (둘 다 KRW 환산 evalAmount)
      */
@@ -332,7 +347,7 @@ public class BalanceService {
                 .anyMatch(cb -> "USD".equals(cb.getCurrencyCode())
                         && cb.getTotalAmount().compareTo(BigDecimal.ZERO) > 0)
                 || holdings.stream().anyMatch(h -> "USD".equals(h.getInstrument().getCurrencyCode()));
-        BigDecimal usdKrwRate = hasUsdExposure ? resolveUsdKrwRate() : BigDecimal.ZERO;
+        BigDecimal usdKrwRate = hasUsdExposure ? resolveUsdKrwDisplayRate() : BigDecimal.ZERO;
 
         Map<Long, BigDecimal> priceMap = resolveHoldingPrices(holdings);
 
@@ -419,9 +434,9 @@ public class BalanceService {
         };
     }
 
-    /** USD/KRW 환율 조회. 없으면 503 예외. */
-    private BigDecimal resolveUsdKrwRate() {
-        BigDecimal rate = priceLookupService.resolveUsdKrwRate();
+    /** USD/KRW 환율 조회 (자산/표시용). 없으면 503 예외. */
+    private BigDecimal resolveUsdKrwDisplayRate() {
+        BigDecimal rate = priceLookupService.resolveUsdKrwDisplayRate();
         if (rate == null || rate.compareTo(BigDecimal.ZERO) <= 0) {
             throw new BusinessException(BalanceErrorCode.EXCHANGE_RATE_UNAVAILABLE);
         }
@@ -485,7 +500,7 @@ public class BalanceService {
                 .anyMatch(cb -> "USD".equals(cb.getCurrencyCode())
                         && cb.getTotalAmount().compareTo(BigDecimal.ZERO) > 0)
                 || holdings.stream().anyMatch(h -> "USD".equals(h.getInstrument().getCurrencyCode()));
-        BigDecimal usdKrwRate = hasUsdExposure ? resolveUsdKrwRate() : BigDecimal.ZERO;
+        BigDecimal usdKrwRate = hasUsdExposure ? resolveUsdKrwDisplayRate() : BigDecimal.ZERO;
 
         BigDecimal cashKrwAmount = cashBalances.stream()
                 .filter(cb -> "KRW".equals(cb.getCurrencyCode()))

--- a/src/main/java/com/sollite/balance/service/BalanceService.java
+++ b/src/main/java/com/sollite/balance/service/BalanceService.java
@@ -2,6 +2,7 @@ package com.sollite.balance.service;
 
 import com.sollite.account.domain.entity.Account;
 import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.AccountStatus;
 import com.sollite.account.domain.enums.RoundStatus;
 import com.sollite.account.domain.repository.AccountRepository;
 import com.sollite.account.domain.repository.SimulationRoundRepository;
@@ -312,6 +313,34 @@ public class BalanceService {
                 .toList();
 
         return new AssetFlowResponse(points);
+    }
+
+    /**
+     * 활성 라운드 전체의 일일 스냅샷을 순차 적재한다 (스케줄러·부트스트랩 공용).
+     */
+    public void captureSnapshotsForActiveRounds(String trigger) {
+        List<SimulationRound> activeRounds =
+                simulationRoundRepository.findAllActiveWithAccountByRoundStatus(RoundStatus.ACTIVE, AccountStatus.ACTIVE);
+
+        int success = 0;
+        int failed = 0;
+
+        for (SimulationRound round : activeRounds) {
+            try {
+                captureDailySnapshot(round.getAccount(), round);
+                success++;
+            } catch (Exception e) {
+                failed++;
+                log.error("[SNAPSHOT][{}] 스냅샷 적재 실패 - accountId={}, roundId={}, error={}",
+                        trigger,
+                        round.getAccount().getAccountId(),
+                        round.getSimulationRoundId(),
+                        e.getMessage(), e);
+            }
+        }
+
+        log.info("[SNAPSHOT][{}] 스냅샷 적재 완료 - total={}, success={}, failed={}",
+                trigger, activeRounds.size(), success, failed);
     }
 
     /**

--- a/src/main/java/com/sollite/balance/service/PortfolioSnapshotBootstrapRunner.java
+++ b/src/main/java/com/sollite/balance/service/PortfolioSnapshotBootstrapRunner.java
@@ -1,0 +1,48 @@
+package com.sollite.balance.service;
+
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.RoundStatus;
+import com.sollite.account.domain.repository.SimulationRoundRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.balance.snapshot", name = "bootstrap-on-startup", havingValue = "true")
+public class PortfolioSnapshotBootstrapRunner implements ApplicationRunner {
+
+    private final SimulationRoundRepository simulationRoundRepository;
+    private final BalanceService balanceService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<SimulationRound> activeRounds =
+                simulationRoundRepository.findAllActiveWithAccountByRoundStatus(RoundStatus.ACTIVE);
+
+        int success = 0;
+        int failed = 0;
+
+        for (SimulationRound round : activeRounds) {
+            try {
+                balanceService.captureDailySnapshot(round.getAccount(), round);
+                success++;
+            } catch (Exception e) {
+                failed++;
+                log.error("[SNAPSHOT] 부트스트랩 스냅샷 적재 실패 - accountId={}, roundId={}, error={}",
+                        round.getAccount().getAccountId(),
+                        round.getSimulationRoundId(),
+                        e.getMessage(), e);
+            }
+        }
+
+        log.info("[SNAPSHOT] 부트스트랩 스냅샷 적재 완료 - total={}, success={}, failed={}",
+                activeRounds.size(), success, failed);
+    }
+}

--- a/src/main/java/com/sollite/balance/service/PortfolioSnapshotBootstrapRunner.java
+++ b/src/main/java/com/sollite/balance/service/PortfolioSnapshotBootstrapRunner.java
@@ -1,8 +1,5 @@
 package com.sollite.balance.service;
 
-import com.sollite.account.domain.entity.SimulationRound;
-import com.sollite.account.domain.enums.RoundStatus;
-import com.sollite.account.domain.repository.SimulationRoundRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -10,39 +7,16 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "app.balance.snapshot", name = "bootstrap-on-startup", havingValue = "true")
 public class PortfolioSnapshotBootstrapRunner implements ApplicationRunner {
 
-    private final SimulationRoundRepository simulationRoundRepository;
     private final BalanceService balanceService;
 
     @Override
     public void run(ApplicationArguments args) {
-        List<SimulationRound> activeRounds =
-                simulationRoundRepository.findAllActiveWithAccountByRoundStatus(RoundStatus.ACTIVE);
-
-        int success = 0;
-        int failed = 0;
-
-        for (SimulationRound round : activeRounds) {
-            try {
-                balanceService.captureDailySnapshot(round.getAccount(), round);
-                success++;
-            } catch (Exception e) {
-                failed++;
-                log.error("[SNAPSHOT] 부트스트랩 스냅샷 적재 실패 - accountId={}, roundId={}, error={}",
-                        round.getAccount().getAccountId(),
-                        round.getSimulationRoundId(),
-                        e.getMessage(), e);
-            }
-        }
-
-        log.info("[SNAPSHOT] 부트스트랩 스냅샷 적재 완료 - total={}, success={}, failed={}",
-                activeRounds.size(), success, failed);
+        balanceService.captureSnapshotsForActiveRounds("BOOTSTRAP");
     }
 }

--- a/src/main/java/com/sollite/balance/service/PortfolioSnapshotScheduler.java
+++ b/src/main/java/com/sollite/balance/service/PortfolioSnapshotScheduler.java
@@ -1,0 +1,56 @@
+package com.sollite.balance.service;
+
+import com.sollite.account.domain.entity.SimulationRound;
+import com.sollite.account.domain.enums.RoundStatus;
+import com.sollite.account.domain.repository.SimulationRoundRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PortfolioSnapshotScheduler {
+
+    private final SimulationRoundRepository simulationRoundRepository;
+    private final BalanceService balanceService;
+
+    @Value("${app.balance.snapshot.enabled:true}")
+    private boolean enabled;
+
+    /**
+     * 국내+미국 혼합 포트폴리오 기준으로 미국장 종료 이후(KST 오전) 일일 스냅샷 적재.
+     */
+    @Scheduled(cron = "${app.balance.snapshot.cron:0 0 7 * * MON-FRI}", zone = "Asia/Seoul")
+    public void captureDailySnapshots() {
+        if (!enabled) {
+            return;
+        }
+
+        List<SimulationRound> activeRounds =
+                simulationRoundRepository.findAllActiveWithAccountByRoundStatus(RoundStatus.ACTIVE);
+
+        int success = 0;
+        int failed = 0;
+
+        for (SimulationRound round : activeRounds) {
+            try {
+                balanceService.captureDailySnapshot(round.getAccount(), round);
+                success++;
+            } catch (Exception e) {
+                failed++;
+                log.error("[SNAPSHOT] 일일 스냅샷 적재 실패 - accountId={}, roundId={}, error={}",
+                        round.getAccount().getAccountId(),
+                        round.getSimulationRoundId(),
+                        e.getMessage(), e);
+            }
+        }
+
+        log.info("[SNAPSHOT] 일일 스냅샷 적재 완료 - total={}, success={}, failed={}",
+                activeRounds.size(), success, failed);
+    }
+}

--- a/src/main/java/com/sollite/balance/service/PortfolioSnapshotScheduler.java
+++ b/src/main/java/com/sollite/balance/service/PortfolioSnapshotScheduler.java
@@ -1,22 +1,16 @@
 package com.sollite.balance.service;
 
-import com.sollite.account.domain.entity.SimulationRound;
-import com.sollite.account.domain.enums.RoundStatus;
-import com.sollite.account.domain.repository.SimulationRoundRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PortfolioSnapshotScheduler {
 
-    private final SimulationRoundRepository simulationRoundRepository;
     private final BalanceService balanceService;
 
     @Value("${app.balance.snapshot.enabled:true}")
@@ -30,27 +24,6 @@ public class PortfolioSnapshotScheduler {
         if (!enabled) {
             return;
         }
-
-        List<SimulationRound> activeRounds =
-                simulationRoundRepository.findAllActiveWithAccountByRoundStatus(RoundStatus.ACTIVE);
-
-        int success = 0;
-        int failed = 0;
-
-        for (SimulationRound round : activeRounds) {
-            try {
-                balanceService.captureDailySnapshot(round.getAccount(), round);
-                success++;
-            } catch (Exception e) {
-                failed++;
-                log.error("[SNAPSHOT] 일일 스냅샷 적재 실패 - accountId={}, roundId={}, error={}",
-                        round.getAccount().getAccountId(),
-                        round.getSimulationRoundId(),
-                        e.getMessage(), e);
-            }
-        }
-
-        log.info("[SNAPSHOT] 일일 스냅샷 적재 완료 - total={}, success={}, failed={}",
-                activeRounds.size(), success, failed);
+        balanceService.captureSnapshotsForActiveRounds("SCHEDULER");
     }
 }

--- a/src/main/java/com/sollite/balance/service/PriceLookupService.java
+++ b/src/main/java/com/sollite/balance/service/PriceLookupService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.balance.dto.PriceQuote;
 import com.sollite.foreignmarket.service.ForeignStockMarketService;
 import com.sollite.index.service.IndexService;
+import com.sollite.market.dto.ForexChartResponse;
+import com.sollite.market.service.ForexService;
 import com.sollite.market.service.MarketService;
 import com.sollite.websocket.service.LsBrokerService;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +42,7 @@ public class PriceLookupService {
     private final MarketService marketService;
     private final ForeignStockMarketService foreignStockMarketService;
     private final IndexService indexService;
+    private final ForexService forexService;
     private final ObjectMapper objectMapper;
     private final StringRedisTemplate redisTemplate;
 
@@ -48,6 +51,7 @@ public class PriceLookupService {
 
     private static final String BALANCE_PRICE_SNAPSHOT_PREFIX = "balance:price:snapshot:";
     private static final Duration BALANCE_PRICE_SNAPSHOT_TTL = Duration.ofHours(48);
+    private static final String USD_KRW_DISPLAY_SNAPSHOT_KEY = BALANCE_PRICE_SNAPSHOT_PREFIX + "fx:display:USDKRW";
 
     // ── 국내 ──────────────────────────────────────────────────────────────────
 
@@ -122,21 +126,70 @@ public class PriceLookupService {
 
     // ── 환율 ──────────────────────────────────────────────────────────────────
 
-    /** USD/KRW 환율 조회 (1 USD = X KRW). WS lastValue → Redis snapshot → indices 캐시 순으로 폴백. */
+    /** USD/KRW 환율 조회 (거래/체결용). WS lastValue → indices 캐시 → Yahoo 순으로 폴백. */
     public BigDecimal resolveUsdKrwRate() {
         BigDecimal rate = parsePriceFromLastValue("/topic/currency/USD");
         if (isValidPrice(rate)) return rate;
 
         try {
-            return indexService.getIndices().stream()
+            rate = indexService.getIndices().stream()
                     .filter(i -> "USD".equals(i.code()) && i.price() != null && i.price() > 0)
                     .map(i -> BigDecimal.valueOf(i.price()))
                     .findFirst()
                     .orElse(null);
+            if (isValidPrice(rate)) {
+                return rate;
+            }
         } catch (Exception e) {
             log.warn("[PriceLookup] indices 캐시 환율 폴백 실패", e);
-            return null;
         }
+
+        try {
+            ForexChartResponse chart = forexService.getForexChart("KRW=X", "1d", "1d");
+            rate = chart.data().isEmpty() ? null : chart.data().get(chart.data().size() - 1).close();
+            if (isValidPrice(rate)) {
+                return rate;
+            }
+        } catch (Exception e) {
+            log.warn("[PriceLookup] Yahoo 환율 폴백 실패", e);
+        }
+
+        return null;
+    }
+
+    /** USD/KRW 환율 조회 (자산/표시용). WS → Redis snapshot → Yahoo 순으로 빠르게 폴백. */
+    public BigDecimal resolveUsdKrwDisplayRate() {
+        BigDecimal rate = parsePriceFromLastValue("/topic/currency/USD");
+        if (isValidPrice(rate)) {
+            persistQuote(USD_KRW_DISPLAY_SNAPSHOT_KEY, rate, "WS", false, LocalDateTime.now());
+            return rate;
+        }
+
+        PriceQuote snapshot = readSnapshot(USD_KRW_DISPLAY_SNAPSHOT_KEY);
+        if (snapshot != null && isValidPrice(snapshot.price())) {
+            return snapshot.price();
+        }
+
+        BigDecimal yahooRate = resolveUsdKrwFromYahoo();
+        if (isValidPrice(yahooRate)) {
+            persistQuote(USD_KRW_DISPLAY_SNAPSHOT_KEY, yahooRate, "YAHOO", false, LocalDateTime.now());
+            return yahooRate;
+        }
+
+        return null;
+    }
+
+    private BigDecimal resolveUsdKrwFromYahoo() {
+        try {
+            ForexChartResponse chart = forexService.getForexChart("KRW=X", "1d", "1d");
+            BigDecimal rate = chart.data().isEmpty() ? null : chart.data().get(chart.data().size() - 1).close();
+            if (isValidPrice(rate)) {
+                return rate;
+            }
+        } catch (Exception e) {
+            log.warn("[PriceLookup] Yahoo 환율 폴백 실패", e);
+        }
+        return null;
     }
 
     // ── 내부 ──────────────────────────────────────────────────────────────────

--- a/src/main/java/com/sollite/balance/service/PriceLookupService.java
+++ b/src/main/java/com/sollite/balance/service/PriceLookupService.java
@@ -144,15 +144,8 @@ public class PriceLookupService {
             log.warn("[PriceLookup] indices 캐시 환율 폴백 실패", e);
         }
 
-        try {
-            ForexChartResponse chart = forexService.getForexChart("KRW=X", "1d", "1d");
-            rate = chart.data().isEmpty() ? null : chart.data().get(chart.data().size() - 1).close();
-            if (isValidPrice(rate)) {
-                return rate;
-            }
-        } catch (Exception e) {
-            log.warn("[PriceLookup] Yahoo 환율 폴백 실패", e);
-        }
+        BigDecimal yahooRate = resolveUsdKrwFromYahoo();
+        if (isValidPrice(yahooRate)) return yahooRate;
 
         return null;
     }

--- a/src/main/java/com/sollite/global/config/SchedulingConfig.java
+++ b/src/main/java/com/sollite/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.sollite.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/sollite/index/service/LsIndexServiceImpl.java
+++ b/src/main/java/com/sollite/index/service/LsIndexServiceImpl.java
@@ -47,7 +47,7 @@ class LsIndexServiceImpl implements IndexService {
     );
 
     @Override
-    @Cacheable(cacheNames = "market:indices", key = "'fixed'", sync = true,
+    @Cacheable(cacheNames = "market:indices", key = "'fixed'",
             unless = "#result.?[code == 'USD' && price == null].size() > 0")
     public List<IndexResponse> getIndices() {
         List<IndexResponse> result = new ArrayList<>();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,7 +104,7 @@ app:
     snapshot:
       enabled: true
       cron: "0 0 7 * * MON-FRI"
-      bootstrap-on-startup: true
+      bootstrap-on-startup: false
 
 # ── Logging ──
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,6 +100,11 @@ app:
         target-delay-ms: 1000
         rate-limit-retry-delay-ms: 5000
         rate-limit-max-retries: 5
+  balance:
+    snapshot:
+      enabled: true
+      cron: "0 0 7 * * MON-FRI"
+      bootstrap-on-startup: true
 
 # ── Logging ──
 logging:


### PR DESCRIPTION
## 개요

USD/KRW 환율 조회 로직을 표시용/거래용으로 분리하고, Yahoo Finance 폴백을 보강합니다.
또한 일일 포트폴리오 스냅샷을 자동 적재하는 스케줄러 및 부트스트랩 러너를 추가합니다.

## 변경 사항

### fix(index): 지수 캐시 예외 수정
- `LsIndexServiceImpl` 지수 캐시 조회 시 발생하던 예외 처리 수정

### fix(balance): USD/KRW 환율 표시용/거래용 분리 및 Yahoo 폴백 보강
- `PriceLookupService`에 `resolveUsdKrwDisplayRate()` 추가 (자산 표시용)
  - WS lastValue → Redis snapshot → Yahoo Finance 순 폴백
- 기존 `resolveUsdKrwRate()` (거래용)에 Yahoo Finance 최종 폴백 추가
- `BalanceService`에서 표시용 환율은 `resolveUsdKrwDisplayRate()` 사용으로 변경
- `BalanceService.captureDailySnapshot()` 메서드 추가 (스케줄러 연동용)

### feat(balance): 일일 포트폴리오 스냅샷 스케줄러 및 부트스트랩 러너 추가
- `PortfolioSnapshotScheduler`: 평일 오전 7시(KST) 모든 활성 라운드 스냅샷 적재
- `PortfolioSnapshotBootstrapRunner`: 서버 시작 시 당일 스냅샷 즉시 적재
- `SimulationRoundRepository.findAllActiveWithAccountByRoundStatus()` 쿼리 추가
- `SchedulingConfig` (`@EnableScheduling`) 추가
- `application.yml`에 `app.balance.snapshot` 설정 추가

## 테스트 체크리스트

- [ ] 서버 기동 시 부트스트랩 스냅샷 적재 로그 확인
- [ ] `/api/balance/summary` 환율 정상 응답 확인
- [ ] Redis에 `balance:price:snapshot:fx:display:USDKRW` 키 저장 확인