### PR TITLE
feat(user): 현재 비밀번호 검증 API 추가

### DIFF
--- a/src/main/java/com/sollite/user/controller/UserController.java
+++ b/src/main/java/com/sollite/user/controller/UserController.java
@@ -53,6 +53,22 @@ public class UserController {
     }
 
     /**
+     * 현재 비밀번호를 검증합니다. 비밀번호 변경 폼에서 onBlur 시 호출됩니다.
+     *
+     * @param authentication 현재 인증된 사용자 정보
+     * @param request 검증할 현재 비밀번호
+     * @return 200 OK - 검증 성공 메시지
+     * @throws BusinessException 비밀번호 불일치 시
+     */
+    @PostMapping("/verify-password")
+    public ResponseEntity<MessageResponse> verifyPassword(Authentication authentication,
+                                                          @Valid @RequestBody PasswordVerifyRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        userService.verifyPassword(userId, request.currentPassword());
+        return ResponseEntity.ok(new MessageResponse("비밀번호가 확인되었습니다."));
+    }
+
+    /**
      * 현재 사용자의 비밀번호를 변경합니다.
      *
      * @param authentication 현재 인증된 사용자 정보

--- a/src/main/java/com/sollite/user/dto/PasswordVerifyRequest.java
+++ b/src/main/java/com/sollite/user/dto/PasswordVerifyRequest.java
@@ -1,0 +1,9 @@
+package com.sollite.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordVerifyRequest(
+        @NotBlank(message = "현재 비밀번호는 필수입니다")
+        String currentPassword
+) {
+}

--- a/src/main/java/com/sollite/user/service/UserService.java
+++ b/src/main/java/com/sollite/user/service/UserService.java
@@ -37,6 +37,22 @@ public class UserService {
     private final LoginAttemptService loginAttemptService;
     private final EmailService emailService;
 
+    private static final int    VERIFY_PW_RATE_LIMIT = 10;         // 10분 내 10회
+    private static final long   VERIFY_PW_RATE_TTL   = 600;        // 10분 (초)
+    private static final String VERIFY_PW_LIMIT_KEY  = "verify_pw_limit:";
+
+    private static final RedisScript<Long> CHECK_RATE_SCRIPT = RedisScript.of(
+            "local c = redis.call('GET', KEYS[1]) " +
+            "if c == false then return 0 end " +
+            "return tonumber(c)",
+            Long.class);
+
+    private static final RedisScript<Long> INCR_RATE_SCRIPT = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1]) " +
+            "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
+            "return c",
+            Long.class);
+
     // 검증 + 삭제 원자 처리: 1=성공, 0=이미 없음(멱등), -1=토큰 불일치
     private static final RedisScript<Long> LOGOUT_SCRIPT = RedisScript.of(
             "local s = redis.call('GET', KEYS[1]) " +
@@ -309,19 +325,21 @@ public class UserService {
 
     /**
      * 현재 비밀번호를 검증합니다. 비밀번호 변경 폼에서 onBlur 시 호출됩니다.
+     * 10분 내 10회 초과 시 TOO_MANY_REQUESTS를 반환합니다.
      *
      * @param userId 사용자 ID
      * @param currentPassword 검증할 현재 비밀번호
-     * @throws BusinessException 비밀번호 불일치, 사용자 미등록 시
+     * @throws BusinessException 요청 초과, 비밀번호 불일치, 사용자 미등록 시
      */
     @Transactional(readOnly = true)
     public void verifyPassword(Long userId, String currentPassword) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        if (!passwordEncoder.matches(currentPassword, user.getPasswordHash())) {
-            throw new BusinessException(UserErrorCode.INVALID_PASSWORD);
+        String rateLimitKey = VERIFY_PW_LIMIT_KEY + userId;
+        Long count = redisTemplate.execute(CHECK_RATE_SCRIPT, List.of(rateLimitKey));
+        if (count != null && count >= VERIFY_PW_RATE_LIMIT) {
+            throw new BusinessException(UserErrorCode.TOO_MANY_REQUESTS);
         }
+        redisTemplate.execute(INCR_RATE_SCRIPT, List.of(rateLimitKey), String.valueOf(VERIFY_PW_RATE_TTL));
+        loadAndVerifyPassword(userId, currentPassword);
     }
 
     /**
@@ -336,16 +354,18 @@ public class UserService {
         if (!request.newPassword().equals(request.newPasswordConfirm())) {
             throw new BusinessException(UserErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
-            throw new BusinessException(UserErrorCode.INVALID_PASSWORD);
-        }
-
+        User user = loadAndVerifyPassword(userId, request.currentPassword());
         user.changePassword(passwordEncoder.encode(request.newPassword()));
         redisTemplate.delete("refresh:" + userId);
+    }
+
+    private User loadAndVerifyPassword(Long userId, String rawPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        if (!passwordEncoder.matches(rawPassword, user.getPasswordHash())) {
+            throw new BusinessException(UserErrorCode.INVALID_PASSWORD);
+        }
+        return user;
     }
 
     private Long parseTokenUserId(java.util.Map<String, String> tokenData) {

--- a/src/main/java/com/sollite/user/service/UserService.java
+++ b/src/main/java/com/sollite/user/service/UserService.java
@@ -308,6 +308,23 @@ public class UserService {
     }
 
     /**
+     * 현재 비밀번호를 검증합니다. 비밀번호 변경 폼에서 onBlur 시 호출됩니다.
+     *
+     * @param userId 사용자 ID
+     * @param currentPassword 검증할 현재 비밀번호
+     * @throws BusinessException 비밀번호 불일치, 사용자 미등록 시
+     */
+    @Transactional(readOnly = true)
+    public void verifyPassword(Long userId, String currentPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(currentPassword, user.getPasswordHash())) {
+            throw new BusinessException(UserErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    /**
      * 현재 비밀번호를 검증하고 새 비밀번호로 변경합니다.
      *
      * @param userId 사용자 ID

--- a/src/test/java/com/sollite/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sollite/user/controller/UserControllerTest.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.global.exception.GlobalExceptionHandler;
 import com.sollite.global.security.JwtTokenProvider;
+import com.sollite.user.domain.enums.ThemeType;
 import com.sollite.user.dto.PasswordChangeRequest;
+import com.sollite.user.dto.PasswordVerifyRequest;
 import com.sollite.user.exception.UserErrorCode;
 import com.sollite.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
@@ -50,7 +53,7 @@ class UserControllerTest {
     private JwtTokenProvider jwtTokenProvider;
 
     private UserProfileResponse createProfileResponse() {
-        return new UserProfileResponse(1L, "test@example.com", "홍길동", "010-1234-5678", true, null, LocalDateTime.of(2026, 3, 16, 0, 0));
+        return new UserProfileResponse(1L, "test@example.com", "홍길동", "010-1234-5678", true, null, LocalDateTime.of(2026, 3, 16, 0, 0), ThemeType.LIGHT);
     }
 
     @Nested
@@ -83,7 +86,7 @@ class UserControllerTest {
         @WithMockUser(username = "1")
         void updateProfile_success() throws Exception {
             ProfileUpdateRequest request = new ProfileUpdateRequest("김길동", "010-9876-5432");
-            UserProfileResponse response = new UserProfileResponse(1L, "test@example.com", "김길동", "010-9876-5432", true, null, LocalDateTime.of(2026, 3, 16, 0, 0));
+            UserProfileResponse response = new UserProfileResponse(1L, "test@example.com", "김길동", "010-9876-5432", true, null, LocalDateTime.of(2026, 3, 16, 0, 0), ThemeType.LIGHT);
             given(userService.updateProfile(eq(1L), any(ProfileUpdateRequest.class))).willReturn(response);
 
             mockMvc.perform(patch("/api/users/me")
@@ -103,6 +106,72 @@ class UserControllerTest {
             ProfileUpdateRequest request = new ProfileUpdateRequest("김길동", "invalid-phone");
 
             mockMvc.perform(patch("/api/users/me")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 비밀번호 검증 API")
+    class VerifyPassword {
+
+        @Test
+        @DisplayName("비밀번호 검증 성공 - 200 OK")
+        @WithMockUser(username = "1")
+        void verifyPassword_success() throws Exception {
+            PasswordVerifyRequest request = new PasswordVerifyRequest("Test1234!");
+            doNothing().when(userService).verifyPassword(eq(1L), eq("Test1234!"));
+
+            mockMvc.perform(post("/api/users/me/verify-password")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("비밀번호가 확인되었습니다."));
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패 - 비밀번호 불일치 401")
+        @WithMockUser(username = "1")
+        void verifyPassword_fail_wrongPassword() throws Exception {
+            PasswordVerifyRequest request = new PasswordVerifyRequest("Wrong1234!");
+            doThrow(new BusinessException(UserErrorCode.INVALID_PASSWORD))
+                    .when(userService).verifyPassword(eq(1L), eq("Wrong1234!"));
+
+            mockMvc.perform(post("/api/users/me/verify-password")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("INVALID_PASSWORD"));
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패 - 요청 초과 429")
+        @WithMockUser(username = "1")
+        void verifyPassword_fail_tooManyRequests() throws Exception {
+            PasswordVerifyRequest request = new PasswordVerifyRequest("Test1234!");
+            doThrow(new BusinessException(UserErrorCode.TOO_MANY_REQUESTS))
+                    .when(userService).verifyPassword(eq(1L), any());
+
+            mockMvc.perform(post("/api/users/me/verify-password")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isTooManyRequests())
+                    .andExpect(jsonPath("$.code").value("TOO_MANY_REQUESTS"));
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패 - 빈 값 400")
+        @WithMockUser(username = "1")
+        void verifyPassword_fail_blank() throws Exception {
+            PasswordVerifyRequest request = new PasswordVerifyRequest("");
+
+            mockMvc.perform(post("/api/users/me/verify-password")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/sollite/user/service/UserServiceTest.java
+++ b/src/test/java/com/sollite/user/service/UserServiceTest.java
@@ -17,10 +17,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -234,36 +237,31 @@ class UserServiceTest {
         @Test
         @DisplayName("로그아웃 성공")
         void logout_success() {
-            given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get("refresh:1")).willReturn("valid-refresh-token");
+            given(redisTemplate.execute(any(RedisScript.class), anyList(), any())).willReturn(1L);
 
-            userService.logout(1L, "valid-refresh-token");
+            userService.logout(1L, "valid-refresh-token", null);
 
-            verify(redisTemplate).delete("refresh:1");
+            verify(redisTemplate).execute(any(RedisScript.class), anyList(), any());
         }
 
         @Test
         @DisplayName("로그아웃 실패 - 유효하지 않은 리프레시 토큰")
         void logout_fail_invalidToken() {
-            given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get("refresh:1")).willReturn("stored-token");
+            given(redisTemplate.execute(any(RedisScript.class), anyList(), any())).willReturn(-1L);
 
-            assertThatThrownBy(() -> userService.logout(1L, "wrong-token"))
+            assertThatThrownBy(() -> userService.logout(1L, "wrong-token", null))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(UserErrorCode.INVALID_TOKEN));
         }
 
         @Test
-        @DisplayName("로그아웃 실패 - 이미 로그아웃된 상태")
-        void logout_fail_alreadyLoggedOut() {
-            given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get("refresh:1")).willReturn(null);
+        @DisplayName("로그아웃 - 이미 로그아웃된 상태는 성공으로 처리 (멱등)")
+        void logout_alreadyLoggedOut_isIdempotent() {
+            given(redisTemplate.execute(any(RedisScript.class), anyList(), any())).willReturn(0L);
 
-            assertThatThrownBy(() -> userService.logout(1L, "some-token"))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                            .isEqualTo(UserErrorCode.INVALID_TOKEN));
+            assertThatCode(() -> userService.logout(1L, "some-token", null))
+                    .doesNotThrowAnyException();
         }
     }
 
@@ -275,17 +273,16 @@ class UserServiceTest {
         @DisplayName("토큰 갱신 성공")
         void refreshToken_success() {
             User user = createUser();
+            long remainingTtl = 604800000L;
 
             given(jwtTokenProvider.validateToken("valid-refresh-token")).willReturn(true);
             given(jwtTokenProvider.getUserIdFromToken("valid-refresh-token")).willReturn(1L);
-            given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get("refresh:1")).willReturn("valid-refresh-token");
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
             given(jwtTokenProvider.createAccessToken(any(), eq("test@example.com"))).willReturn("new-access-token");
             given(jwtTokenProvider.createRefreshToken(any(), anyLong())).willReturn("new-refresh-token");
-            given(redisTemplate.getExpire("refresh:1", TimeUnit.MILLISECONDS)).willReturn(0L);
-            given(jwtTokenProvider.getRefreshTokenExpiry(false)).willReturn(604800000L);
+            given(redisTemplate.getExpire("refresh:1", TimeUnit.MILLISECONDS)).willReturn(remainingTtl);
             given(jwtTokenProvider.getAccessTokenExpiry()).willReturn(1800000L);
+            given(redisTemplate.execute(any(RedisScript.class), anyList(), any(), any(), any())).willReturn(1L);
 
             TokenRefreshResult result = userService.refreshToken("valid-refresh-token");
 
@@ -441,6 +438,63 @@ class UserServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(UserErrorCode.TOKEN_EXPIRED));
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 비밀번호 검증 (verifyPassword)")
+    class VerifyPassword {
+
+        @Test
+        @DisplayName("비밀번호 검증 성공")
+        void verifyPassword_success() {
+            User user = createUser();
+            given(redisTemplate.execute(any(RedisScript.class), anyList())).willReturn(0L);
+            given(redisTemplate.execute(any(RedisScript.class), anyList(), anyString())).willReturn(1L);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches("Test1234!", "encodedPassword")).willReturn(true);
+
+            assertThatCode(() -> userService.verifyPassword(1L, "Test1234!"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패 - 비밀번호 불일치")
+        void verifyPassword_fail_wrongPassword() {
+            User user = createUser();
+            given(redisTemplate.execute(any(RedisScript.class), anyList())).willReturn(0L);
+            given(redisTemplate.execute(any(RedisScript.class), anyList(), anyString())).willReturn(1L);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches("Wrong1234!", "encodedPassword")).willReturn(false);
+
+            assertThatThrownBy(() -> userService.verifyPassword(1L, "Wrong1234!"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(UserErrorCode.INVALID_PASSWORD));
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패 - 존재하지 않는 사용자")
+        void verifyPassword_fail_userNotFound() {
+            given(redisTemplate.execute(any(RedisScript.class), anyList())).willReturn(0L);
+            given(redisTemplate.execute(any(RedisScript.class), anyList(), anyString())).willReturn(1L);
+            given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.verifyPassword(99L, "Test1234!"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패 - 요청 횟수 초과 (Rate Limit)")
+        void verifyPassword_fail_tooManyRequests() {
+            given(redisTemplate.execute(any(RedisScript.class), anyList())).willReturn(10L);
+
+            assertThatThrownBy(() -> userService.verifyPassword(1L, "Test1234!"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(UserErrorCode.TOO_MANY_REQUESTS));
         }
     }
 


### PR DESCRIPTION
## 변경사항

- `POST /api/users/me/verify-password` 엔드포인트 추가
- `PasswordVerifyRequest` DTO 추가
- `UserService.verifyPassword()` 추가 — 현재 비밀번호 일치 여부 검증

## 작업 내용

프론트엔드 계정 설정 패널에서 비밀번호 변경 폼의 현재 비밀번호 필드 blur 시점에 서버 측 실시간 검증을 수행하기 위한 API를 추가했습니다.

- `PasswordVerifyRequest`: `currentPassword` 필드에 `@NotBlank` 검증 적용
- `UserService.verifyPassword()`: `passwordEncoder.matches()`로 BCrypt 비밀번호 검증, 불일치 시 `INVALID_PASSWORD` 예외 발생
- `UserController`: 기존 `/me` 하위 구조를 그대로 유지하며 엔드포인트 추가

## 체크리스트

- [ ] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [ ] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

없음