### PR TITLE
feat(widget): 프리셋 적용 API 구현 및 시가총액 기반 종목 정렬 적용

### DIFF
--- a/src/main/java/com/sollite/market/domain/entity/Instrument.java
+++ b/src/main/java/com/sollite/market/domain/entity/Instrument.java
@@ -55,6 +55,9 @@ public class Instrument {
     @Column(name = "active_yn", nullable = false, columnDefinition = "CHAR(1)")
     private String activeYn;
 
+    @Column(name = "market_cap")
+    private Long marketCap;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/sollite/market/domain/enums/StockTheme.java
+++ b/src/main/java/com/sollite/market/domain/enums/StockTheme.java
@@ -15,7 +15,7 @@ public enum StockTheme {
     FINANCE("금융"),
     SHIPBUILDING("조선"),
     DEFENSE("방산"),
-    MANUFACTURING("제조업"),
+    MANUFACTURING("인프라 & 산업재"),
     ROBOT("로봇");
 
     private final String displayName;

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentThemeMappingRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentThemeMappingRepository.java
@@ -6,10 +6,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Set;
+import com.sollite.market.domain.entity.Instrument;
 
 public interface InstrumentThemeMappingRepository extends JpaRepository<InstrumentThemeMapping, Long> {
 
     @Query("SELECT m.instrument.stockCode FROM InstrumentThemeMapping m WHERE m.themeCode = :theme")
     Set<String> findStockCodesByTheme(@Param("theme") StockTheme theme);
+
+    @Query("SELECT m.instrument FROM InstrumentThemeMapping m JOIN m.instrument WHERE m.themeCode = :theme")
+    List<Instrument> findInstrumentsByTheme(@Param("theme") StockTheme theme);
+
+    @Query("SELECT m.instrument FROM InstrumentThemeMapping m JOIN m.instrument WHERE m.themeCode = :theme ORDER BY m.instrument.marketCap DESC NULLS LAST")
+    List<Instrument> findTopInstrumentByThemeOrderByMarketCapDesc(@Param("theme") StockTheme theme, org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentThemeMappingRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentThemeMappingRepository.java
@@ -15,7 +15,7 @@ public interface InstrumentThemeMappingRepository extends JpaRepository<Instrume
     @Query("SELECT m.instrument.stockCode FROM InstrumentThemeMapping m WHERE m.themeCode = :theme")
     Set<String> findStockCodesByTheme(@Param("theme") StockTheme theme);
 
-    @Query("SELECT m.instrument FROM InstrumentThemeMapping m JOIN m.instrument WHERE m.themeCode = :theme")
+    @Query("SELECT m.instrument FROM InstrumentThemeMapping m WHERE m.themeCode = :theme")
     List<Instrument> findInstrumentsByTheme(@Param("theme") StockTheme theme);
 
     @Query("SELECT m.instrument FROM InstrumentThemeMapping m JOIN m.instrument WHERE m.themeCode = :theme ORDER BY m.instrument.marketCap DESC NULLS LAST")

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -3,6 +3,7 @@ package com.sollite.market.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.global.exception.BusinessException;
 import com.sollite.global.service.LsTokenService;
+import com.sollite.market.domain.entity.Instrument;
 import com.sollite.market.domain.entity.MarketDailyCandle;
 import com.sollite.market.domain.entity.MarketMinuteCandle;
 import com.sollite.market.domain.enums.StockTheme;
@@ -68,6 +69,7 @@ class LsMarketServiceImpl implements MarketService {
     private final MarketMinuteCandleRepository marketMinuteCandleRepository;
     private static final String DUMMY_MAC = "00:00:00:00:00:00";
     private static final String INTEGRATED_EXCHANGE_SCOPE = "U";
+    private static final String SIGN_UNCHANGED = "3"; // LS API sign 코드: 보합
     private final Map<String, MinuteGapCacheEntry> minuteGapCache = new ConcurrentHashMap<>();
     private final Map<String, Object> minuteGapLocks = new ConcurrentHashMap<>();
     private final Set<String> minuteGapRefreshInFlight = ConcurrentHashMap.newKeySet();
@@ -1217,13 +1219,13 @@ class LsMarketServiceImpl implements MarketService {
     @Cacheable(cacheNames = "market:ranking", key = "'theme:' + #theme.name() + ':' + #type", sync = true)
     public List<StockRankingItem> getThemeRanking(StockTheme theme, String type) {
         try {
-            List<com.sollite.market.domain.entity.Instrument> themeInstruments = instrumentThemeMappingRepository.findInstrumentsByTheme(theme);
+            List<Instrument> themeInstruments = instrumentThemeMappingRepository.findInstrumentsByTheme(theme);
             if (themeInstruments.isEmpty()) {
                 return List.of();
             }
 
             Set<String> themeCodes = themeInstruments.stream()
-                    .map(com.sollite.market.domain.entity.Instrument::getStockCode)
+                    .map(Instrument::getStockCode)
                     .collect(java.util.stream.Collectors.toSet());
 
             // @Cacheable 프록시를 통하기 위해 ApplicationContext에서 빈을 직접 조회
@@ -1231,24 +1233,24 @@ class LsMarketServiceImpl implements MarketService {
 
             List<StockRankingItem> filtered = allRanking.stream()
                     .filter(item -> item.stockCode() != null && themeCodes.contains(item.stockCode()))
-                    .collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+                    .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
 
             Set<String> rankedCodes = filtered.stream()
                     .map(StockRankingItem::stockCode)
                     .collect(java.util.stream.Collectors.toSet());
 
-            List<com.sollite.market.domain.entity.Instrument> unrankedInstruments = themeInstruments.stream()
+            List<Instrument> unrankedInstruments = themeInstruments.stream()
                     .filter(inst -> !rankedCodes.contains(inst.getStockCode()))
-                    .collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+                    .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
 
-            unrankedInstruments.sort(java.util.Comparator.comparingLong(
-                    inst -> inst.getMarketCap() != null ? -inst.getMarketCap() : Long.MAX_VALUE
-            ));
+            unrankedInstruments.sort(
+                    Comparator.comparing(Instrument::getMarketCap, Comparator.nullsLast(Comparator.reverseOrder()))
+            );
 
-            for (com.sollite.market.domain.entity.Instrument inst : unrankedInstruments) {
+            for (Instrument inst : unrankedInstruments) {
                 filtered.add(new StockRankingItem(
                         0, inst.getStockCode(), inst.getMarketType(), inst.getStockName(),
-                        0L, "3", 0L, 0.0, 0L, 0L, 0L, null,
+                        0L, SIGN_UNCHANGED, 0L, 0.0, 0L, 0L, 0L, null,
                         null, null, null, null, null, null, null, null, null, null
                 ));
             }
@@ -1265,16 +1267,17 @@ class LsMarketServiceImpl implements MarketService {
     }
 
     @Override
+    @Cacheable(cacheNames = "market:ranking", key = "'theme:top-market-cap:' + #theme.name()", sync = true)
     public StockRankingItem getTopMarketCapStock(StockTheme theme) {
-        List<com.sollite.market.domain.entity.Instrument> top = instrumentThemeMappingRepository
+        List<Instrument> top = instrumentThemeMappingRepository
                 .findTopInstrumentByThemeOrderByMarketCapDesc(theme, PageRequest.of(0, 1));
         if (top.isEmpty()) {
             return null;
         }
-        com.sollite.market.domain.entity.Instrument inst = top.get(0);
+        Instrument inst = top.get(0);
         return new StockRankingItem(
                 1, inst.getStockCode(), inst.getMarketType(), inst.getStockName(),
-                0L, "3", 0L, 0.0, 0L, 0L, inst.getMarketCap(), null,
+                0L, SIGN_UNCHANGED, 0L, 0.0, 0L, 0L, inst.getMarketCap(), null,
                 null, null, null, null, null, null, null, null, null, null
         );
     }

--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -1217,17 +1217,41 @@ class LsMarketServiceImpl implements MarketService {
     @Cacheable(cacheNames = "market:ranking", key = "'theme:' + #theme.name() + ':' + #type", sync = true)
     public List<StockRankingItem> getThemeRanking(StockTheme theme, String type) {
         try {
-            Set<String> themeCodes = instrumentThemeMappingRepository.findStockCodesByTheme(theme);
-            if (themeCodes.isEmpty()) {
+            List<com.sollite.market.domain.entity.Instrument> themeInstruments = instrumentThemeMappingRepository.findInstrumentsByTheme(theme);
+            if (themeInstruments.isEmpty()) {
                 return List.of();
             }
+
+            Set<String> themeCodes = themeInstruments.stream()
+                    .map(com.sollite.market.domain.entity.Instrument::getStockCode)
+                    .collect(java.util.stream.Collectors.toSet());
 
             // @Cacheable 프록시를 통하기 위해 ApplicationContext에서 빈을 직접 조회
             List<StockRankingItem> allRanking = applicationContext.getBean(MarketService.class).getRanking(type, "all");
 
             List<StockRankingItem> filtered = allRanking.stream()
                     .filter(item -> item.stockCode() != null && themeCodes.contains(item.stockCode()))
-                    .toList();
+                    .collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+
+            Set<String> rankedCodes = filtered.stream()
+                    .map(StockRankingItem::stockCode)
+                    .collect(java.util.stream.Collectors.toSet());
+
+            List<com.sollite.market.domain.entity.Instrument> unrankedInstruments = themeInstruments.stream()
+                    .filter(inst -> !rankedCodes.contains(inst.getStockCode()))
+                    .collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+
+            unrankedInstruments.sort(java.util.Comparator.comparingLong(
+                    inst -> inst.getMarketCap() != null ? -inst.getMarketCap() : Long.MAX_VALUE
+            ));
+
+            for (com.sollite.market.domain.entity.Instrument inst : unrankedInstruments) {
+                filtered.add(new StockRankingItem(
+                        0, inst.getStockCode(), inst.getMarketType(), inst.getStockName(),
+                        0L, "3", 0L, 0.0, 0L, 0L, 0L, null,
+                        null, null, null, null, null, null, null, null, null, null
+                ));
+            }
 
             return IntStream.range(0, filtered.size())
                     .mapToObj(i -> filtered.get(i).withRank(i + 1))
@@ -1238,6 +1262,21 @@ class LsMarketServiceImpl implements MarketService {
             log.error("테마 순위 조회 중 예외 발생: theme={}, type={}", theme, type, e);
             throw new BusinessException(MarketErrorCode.MARKET_API_ERROR);
         }
+    }
+
+    @Override
+    public StockRankingItem getTopMarketCapStock(StockTheme theme) {
+        List<com.sollite.market.domain.entity.Instrument> top = instrumentThemeMappingRepository
+                .findTopInstrumentByThemeOrderByMarketCapDesc(theme, PageRequest.of(0, 1));
+        if (top.isEmpty()) {
+            return null;
+        }
+        com.sollite.market.domain.entity.Instrument inst = top.get(0);
+        return new StockRankingItem(
+                1, inst.getStockCode(), inst.getMarketType(), inst.getStockName(),
+                0L, "3", 0L, 0.0, 0L, 0L, inst.getMarketCap(), null,
+                null, null, null, null, null, null, null, null, null, null
+        );
     }
 
     static boolean supportsRankingMarket(String market) {

--- a/src/main/java/com/sollite/market/service/MarketService.java
+++ b/src/main/java/com/sollite/market/service/MarketService.java
@@ -33,6 +33,7 @@ public interface MarketService {
     OrderbookResponse getOrderbook(String stockCode);
     List<StockRankingItem> getRanking(String type, String market);
     List<StockRankingItem> getThemeRanking(StockTheme theme, String type);
+    StockRankingItem getTopMarketCapStock(StockTheme theme);
     StockInfoResponse getStockInfo(String stockCode);
     IndexChartResponse getIndexChart(String indexCode, int count);
     IndexMinuteChartResponse getIndexMinuteChart(String indexCode, int ncnt, int count);

--- a/src/main/java/com/sollite/widget/controller/DashboardController.java
+++ b/src/main/java/com/sollite/widget/controller/DashboardController.java
@@ -3,6 +3,7 @@ package com.sollite.widget.controller;
 import com.sollite.global.util.AuthUtil;
 import com.sollite.widget.dto.DashboardPageResponse;
 import com.sollite.widget.dto.DashboardSaveRequest;
+import com.sollite.widget.dto.PresetApplyRequest;
 import com.sollite.widget.service.DashboardService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +32,13 @@ public class DashboardController {
             @Valid @RequestBody DashboardSaveRequest request) {
         Long userId = AuthUtil.getUserId(authentication);
         return ResponseEntity.ok(dashboardService.saveMyDashboards(userId, request));
+    }
+
+    @PostMapping("/presets/apply")
+    public ResponseEntity<List<DashboardPageResponse>> applyPreset(
+            Authentication authentication,
+            @Valid @RequestBody PresetApplyRequest request) {
+        Long userId = AuthUtil.getUserId(authentication);
+        return ResponseEntity.ok(dashboardService.applyPreset(userId, request));
     }
 }

--- a/src/main/java/com/sollite/widget/dto/PresetApplyRequest.java
+++ b/src/main/java/com/sollite/widget/dto/PresetApplyRequest.java
@@ -1,0 +1,21 @@
+package com.sollite.widget.dto;
+
+import com.sollite.market.domain.enums.StockTheme;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record PresetApplyRequest(
+        @Size(max = 100, message = "프리셋 이름은 100자 이하여야 합니다")
+        String presetName,
+
+        @NotNull(message = "theme은 필수입니다")
+        StockTheme theme,
+
+        @NotEmpty(message = "widgets는 1개 이상이어야 합니다")
+        @Valid
+        List<WidgetLayoutRequest> widgets
+) {}

--- a/src/main/java/com/sollite/widget/exception/WidgetErrorCode.java
+++ b/src/main/java/com/sollite/widget/exception/WidgetErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WidgetErrorCode implements ErrorCode {
 
-    DUPLICATE_PAGE_ORDER(400, "pageOrder 중복 값이 존재합니다");
+    DUPLICATE_PAGE_ORDER(400, "pageOrder 중복 값이 존재합니다"),
+    PAGE_LIMIT_EXCEEDED(400, "대시보드 페이지는 최대 5개까지 생성할 수 있습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/widget/service/DashboardService.java
+++ b/src/main/java/com/sollite/widget/service/DashboardService.java
@@ -1,25 +1,43 @@
 package com.sollite.widget.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sollite.global.exception.BusinessException;
+import com.sollite.market.dto.StockRankingItem;
+import com.sollite.market.service.MarketService;
 import com.sollite.widget.domain.entity.Dashboard;
 import com.sollite.widget.domain.entity.WidgetLayout;
 import com.sollite.widget.domain.repository.DashboardRepository;
 import com.sollite.widget.dto.DashboardPageRequest;
 import com.sollite.widget.dto.DashboardPageResponse;
 import com.sollite.widget.dto.DashboardSaveRequest;
+import com.sollite.widget.dto.PresetApplyRequest;
+import com.sollite.widget.dto.WidgetLayoutRequest;
 import com.sollite.widget.exception.WidgetErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DashboardService {
 
+    private static final int MAX_PAGES = 5;
+    private static final String STOCK_CHART_TYPE = "stock-chart";
+    private static final String STOCK_NEWS_TYPE = "stock-news";
+
     private final DashboardRepository dashboardRepository;
+    private final MarketService marketService;
+    private final ObjectMapper objectMapper;
 
     @Transactional(readOnly = true)
     public List<DashboardPageResponse> getMyDashboards(Long userId) {
@@ -70,5 +88,88 @@ public class DashboardService {
         return dashboardRepository.saveAll(toSave).stream()
                 .map(DashboardPageResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public List<DashboardPageResponse> applyPreset(Long userId, PresetApplyRequest request) {
+        // getThemeRanking은 @Cacheable 처리되어 있어 캐시 히트 시 즉시 반환됨
+        List<StockRankingItem> ranking = marketService.getThemeRanking(request.theme(), "trading-value");
+        StockRankingItem topMarketCapStock = marketService.getTopMarketCapStock(request.theme());
+
+        List<Dashboard> existing = dashboardRepository.findAllByUserIdWithWidgets(userId);
+        if (existing.size() >= MAX_PAGES) {
+            throw new BusinessException(WidgetErrorCode.PAGE_LIMIT_EXCEEDED);
+        }
+
+        AtomicInteger stockIdx = new AtomicInteger(0);
+        List<WidgetLayoutRequest> filledWidgets = request.widgets().stream()
+                .map(w -> {
+                    if (STOCK_NEWS_TYPE.equals(w.widgetType()) && topMarketCapStock != null) {
+                        return new WidgetLayoutRequest(
+                                w.widgetType(), w.positionX(), w.positionY(),
+                                w.width(), w.height(),
+                                buildStockConfigJson(w.configJson(), topMarketCapStock)
+                        );
+                    }
+                    if (!STOCK_CHART_TYPE.equals(w.widgetType())) return w;
+                    int idx = stockIdx.getAndIncrement();
+                    if (idx >= ranking.size()) return w;
+                    return new WidgetLayoutRequest(
+                            w.widgetType(), w.positionX(), w.positionY(),
+                            w.width(), w.height(),
+                            buildStockConfigJson(w.configJson(), ranking.get(idx))
+                    );
+                })
+                .toList();
+
+        int newPageOrder = existing.size() + 1;
+        Dashboard preset = Dashboard.builder()
+                .userId(userId)
+                .dashboardName(request.presetName())
+                .pageOrder(newPageOrder)
+                .defaultYn(existing.isEmpty() ? "Y" : "N")
+                .build();
+
+        filledWidgets.forEach(w -> preset.addWidgetLayout(
+                WidgetLayout.builder()
+                        .dashboard(preset)
+                        .widgetType(w.widgetType())
+                        .positionX(w.positionX())
+                        .positionY(w.positionY())
+                        .width(w.width())
+                        .height(w.height())
+                        .configJson(w.configJson())
+                        .build()
+        ));
+
+        dashboardRepository.save(preset);
+
+        return dashboardRepository.findAllByUserIdWithWidgets(userId).stream()
+                .map(DashboardPageResponse::from)
+                .toList();
+    }
+
+    private String buildStockConfigJson(String existingConfigJson, StockRankingItem stock) {
+        try {
+            Map<String, Object> config = (existingConfigJson != null && !existingConfigJson.isBlank())
+                    ? objectMapper.readValue(existingConfigJson, new TypeReference<>() {})
+                    : new LinkedHashMap<>();
+            config.put("stockCode", stock.stockCode());
+            config.put("stockName", stock.name());
+            config.put("marketType", stock.marketType());
+            return objectMapper.writeValueAsString(config);
+        } catch (JsonProcessingException e) {
+            log.warn("configJson 파싱 실패, 기본 구조로 대체합니다: {}", e.getMessage());
+            try {
+                Map<String, Object> fallback = new LinkedHashMap<>();
+                fallback.put("stockCode", stock.stockCode());
+                fallback.put("stockName", stock.name());
+                fallback.put("marketType", stock.marketType());
+                return objectMapper.writeValueAsString(fallback);
+            } catch (JsonProcessingException ex) {
+                log.error("configJson 직렬화 실패: {}", ex.getMessage());
+                return "{}";
+            }
+        }
     }
 }

--- a/src/main/java/com/sollite/widget/service/DashboardService.java
+++ b/src/main/java/com/sollite/widget/service/DashboardService.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 @Slf4j
@@ -101,7 +100,7 @@ public class DashboardService {
             throw new BusinessException(WidgetErrorCode.PAGE_LIMIT_EXCEEDED);
         }
 
-        AtomicInteger stockIdx = new AtomicInteger(0);
+        int[] stockIdx = {0};
         List<WidgetLayoutRequest> filledWidgets = request.widgets().stream()
                 .map(w -> {
                     if (STOCK_NEWS_TYPE.equals(w.widgetType()) && topMarketCapStock != null) {
@@ -112,7 +111,7 @@ public class DashboardService {
                         );
                     }
                     if (!STOCK_CHART_TYPE.equals(w.widgetType())) return w;
-                    int idx = stockIdx.getAndIncrement();
+                    int idx = stockIdx[0]++;
                     if (idx >= ranking.size()) return w;
                     return new WidgetLayoutRequest(
                             w.widgetType(), w.positionX(), w.positionY(),


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용
- 프리셋 적용 API 추가 (POST /api/dashboards/presets/apply)
- Instrument 엔티티에 market_cap 필드 매핑 추가
- 테마 랭킹 미집계 종목 정렬 방식을 랜덤에서 시가총액 내림차순으로 변경
- stock-news 위젯에 테마 내 시가총액 1위 종목 자동 주입
- PAGE_LIMIT_EXCEEDED 에러 코드 추가

### 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> `getTopMarketCapStock`은 프리셋 적용 시마다 DB를 직접 조회합니다.

> `getThemeRanking`과 달리 캐싱이 적용되어 있지 않은데, 캐시 처리가 필요한지 의견 부탁드립니다.