### PR TITLE
feat(market): 시가총액 초기화 기능 추가 및 검색 정렬 개선

### DIFF
--- a/src/main/java/com/sollite/market/domain/entity/Instrument.java
+++ b/src/main/java/com/sollite/market/domain/entity/Instrument.java
@@ -55,6 +55,9 @@ public class Instrument {
     @Column(name = "active_yn", nullable = false, columnDefinition = "CHAR(1)")
     private String activeYn;
 
+    @Column(name = "market_cap")
+    private Long marketCap;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
@@ -40,7 +40,7 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
         return findExchangeCodesByStockCode(stockCode).stream().findFirst();
     }
 
-    @Query("SELECT DISTINCT i.stockCode FROM Instrument i WHERE i.activeYn = 'Y' AND i.marketType IN ('KOSPI', 'KOSDAQ') AND i.etfYn = 'N'")
+    @Query("SELECT DISTINCT i.stockCode FROM Instrument i WHERE i.activeYn = 'Y' AND i.marketType IN ('KOSPI', 'KOSDAQ') AND i.etfYn = 'N' AND i.marketCap IS NULL")
     List<String> findActiveDomesticNonEtfStockCodes();
 
     @Modifying

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
@@ -2,6 +2,7 @@ package com.sollite.market.domain.repository;
 
 import com.sollite.market.domain.entity.Instrument;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,7 +21,8 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
             "OR i.stockName LIKE CONCAT('%', :keyword, '%') " +
             "OR UPPER(i.stockNameEn) LIKE UPPER(CONCAT('%', :keyword, '%'))) " +
             "ORDER BY CASE WHEN UPPER(i.stockCode) = UPPER(:keyword) THEN 0 " +
-            "WHEN UPPER(i.stockCode) LIKE UPPER(CONCAT(:keyword, '%')) THEN 1 ELSE 2 END")
+            "WHEN UPPER(i.stockCode) LIKE UPPER(CONCAT(:keyword, '%')) THEN 1 ELSE 2 END, " +
+            "CASE WHEN i.marketCap IS NULL THEN 1 ELSE 0 END, i.marketCap DESC")
     List<Instrument> searchByKeyword(@Param("keyword") String keyword);
 
     @Query(value = """
@@ -37,6 +39,25 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
     default Optional<String> findFirstExchangeCodeByStockCode(String stockCode) {
         return findExchangeCodesByStockCode(stockCode).stream().findFirst();
     }
+
+    @Query("SELECT DISTINCT i.stockCode FROM Instrument i WHERE i.activeYn = 'Y' AND i.marketType IN ('KOSPI', 'KOSDAQ') AND i.etfYn = 'N'")
+    List<String> findActiveDomesticNonEtfStockCodes();
+
+    @Modifying
+    @Query("UPDATE Instrument i SET i.marketCap = :marketCap WHERE i.stockCode = :stockCode AND i.marketType IN ('KOSPI', 'KOSDAQ')")
+    void updateMarketCapByStockCode(@Param("stockCode") String stockCode, @Param("marketCap") Long marketCap);
+
+    interface StockCodeExchangeCodeView {
+        String getStockCode();
+        String getExchangeCode();
+    }
+
+    @Query("SELECT DISTINCT i.stockCode AS stockCode, i.exchangeCode AS exchangeCode FROM Instrument i WHERE i.activeYn = 'Y' AND i.marketType IN ('NASDAQ', 'NYSE') AND i.etfYn = 'N' AND i.exchangeCode IS NOT NULL AND i.marketCap IS NULL")
+    List<StockCodeExchangeCodeView> findActiveForeignNonEtfStockCodeExchangePairs();
+
+    @Modifying
+    @Query("UPDATE Instrument i SET i.marketCap = :marketCap WHERE i.stockCode = :stockCode AND i.marketType IN ('NASDAQ', 'NYSE')")
+    void updateMarketCapByForeignStockCode(@Param("stockCode") String stockCode, @Param("marketCap") Long marketCap);
 
     @Query("""
             SELECT i FROM Instrument i

--- a/src/main/java/com/sollite/market/init/MarketCapInitializer.java
+++ b/src/main/java/com/sollite/market/init/MarketCapInitializer.java
@@ -1,0 +1,111 @@
+package com.sollite.market.init;
+
+import com.sollite.foreignmarket.dto.ForeignStockInfoResponse;
+import com.sollite.foreignmarket.service.ForeignStockMarketService;
+import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.market.dto.FinanceResponse;
+import com.sollite.market.service.MarketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.market.cap", name = "enabled", havingValue = "true")
+public class MarketCapInitializer implements ApplicationRunner {
+
+    private final InstrumentRepository instrumentRepository;
+    private final MarketService marketService;
+    private final ForeignStockMarketService foreignStockMarketService;
+
+    @org.springframework.beans.factory.annotation.Value("${app.market.cap.domestic.skip:false}")
+    private boolean skipDomestic;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) throws Exception {
+        if (!skipDomestic) {
+            runDomestic();
+        } else {
+            log.info("[MarketCap] 국내주식 시가총액 초기화 스킵 (app.market.cap.domestic.skip=true)");
+        }
+        runForeign();
+    }
+
+    private void runDomestic() throws InterruptedException {
+        List<String> stockCodes = instrumentRepository.findActiveDomesticNonEtfStockCodes();
+        log.info("[MarketCap] 국내주식 시가총액 초기화 시작: 총 {} 종목", stockCodes.size());
+
+        int updated = 0;
+        for (String stockCode : stockCodes) {
+            try {
+                FinanceResponse finance = marketService.getFinance(stockCode);
+                String raw = finance.marketCap();
+                if (raw != null && !raw.isBlank()) {
+                    long cap = Long.parseLong(raw.trim());
+                    instrumentRepository.updateMarketCapByStockCode(stockCode, cap);
+                    updated++;
+                    log.info("[MarketCap] 국내 {}/{} 완료: stockCode={}, marketCap={}억", updated, stockCodes.size(), stockCode, cap);
+                }
+                Thread.sleep(1100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Exception e) {
+                log.warn("[MarketCap] 국내 조회 실패: stockCode={}, reason={}", stockCode, e.getMessage());
+            }
+        }
+
+        log.info("[MarketCap] 국내주식 완료: {}/{} 종목 업데이트", updated, stockCodes.size());
+    }
+
+    private void runForeign() throws InterruptedException {
+        List<InstrumentRepository.StockCodeExchangeCodeView> pairs =
+                instrumentRepository.findActiveForeignNonEtfStockCodeExchangePairs();
+        log.info("[MarketCap] 해외주식 시가총액 초기화 시작: 총 {} 종목", pairs.size());
+
+        int updated = 0;
+        for (InstrumentRepository.StockCodeExchangeCodeView pair : pairs) {
+            String stockCode = pair.getStockCode();
+            String exchangeCode = pair.getExchangeCode();
+            try {
+                ForeignStockInfoResponse info = foreignStockMarketService.getInfo(stockCode, exchangeCode);
+                long shareprc = info.shareprc();
+                double exrate = info.exrate();
+
+                if (shareprc <= 0 || exrate <= 0) {
+                    log.warn("[MarketCap] 해외 데이터 없음: stockCode={}, shareprc={}, exrate={}", stockCode, shareprc, exrate);
+                    continue;
+                }
+
+                // USD → KRW → 억원
+                long capUkrw = BigDecimal.valueOf(shareprc)
+                        .multiply(BigDecimal.valueOf(exrate))
+                        .divide(BigDecimal.valueOf(100_000_000L), 0, RoundingMode.HALF_UP)
+                        .longValue();
+
+                instrumentRepository.updateMarketCapByForeignStockCode(stockCode, capUkrw);
+                updated++;
+                log.info("[MarketCap] 해외 {}/{} 완료: stockCode={}, shareprc={}USD, marketCap={}억", updated, pairs.size(), stockCode, shareprc, capUkrw);
+
+                Thread.sleep(1100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Exception e) {
+                log.warn("[MarketCap] 해외 조회 실패: stockCode={}, exchangeCode={}, reason={}", stockCode, exchangeCode, e.getMessage());
+            }
+        }
+
+        log.info("[MarketCap] 해외주식 완료: {}/{} 종목 업데이트", updated, pairs.size());
+    }
+}

--- a/src/main/java/com/sollite/market/init/MarketCapInitializer.java
+++ b/src/main/java/com/sollite/market/init/MarketCapInitializer.java
@@ -7,6 +7,7 @@ import com.sollite.market.dto.FinanceResponse;
 import com.sollite.market.service.MarketService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -27,11 +28,10 @@ public class MarketCapInitializer implements ApplicationRunner {
     private final MarketService marketService;
     private final ForeignStockMarketService foreignStockMarketService;
 
-    @org.springframework.beans.factory.annotation.Value("${app.market.cap.domestic.skip:false}")
+    @Value("${app.market.cap.domestic.skip:false}")
     private boolean skipDomestic;
 
     @Override
-    @Transactional
     public void run(ApplicationArguments args) throws Exception {
         if (!skipDomestic) {
             runDomestic();
@@ -52,7 +52,7 @@ public class MarketCapInitializer implements ApplicationRunner {
                 String raw = finance.marketCap();
                 if (raw != null && !raw.isBlank()) {
                     long cap = Long.parseLong(raw.trim());
-                    instrumentRepository.updateMarketCapByStockCode(stockCode, cap);
+                    saveDomesticMarketCap(stockCode, cap);
                     updated++;
                     log.info("[MarketCap] 국내 {}/{} 완료: stockCode={}, marketCap={}억", updated, stockCodes.size(), stockCode, cap);
                 }
@@ -93,7 +93,7 @@ public class MarketCapInitializer implements ApplicationRunner {
                         .divide(BigDecimal.valueOf(100_000_000L), 0, RoundingMode.HALF_UP)
                         .longValue();
 
-                instrumentRepository.updateMarketCapByForeignStockCode(stockCode, capUkrw);
+                saveForeignMarketCap(stockCode, capUkrw);
                 updated++;
                 log.info("[MarketCap] 해외 {}/{} 완료: stockCode={}, shareprc={}USD, marketCap={}억", updated, pairs.size(), stockCode, shareprc, capUkrw);
 
@@ -107,5 +107,15 @@ public class MarketCapInitializer implements ApplicationRunner {
         }
 
         log.info("[MarketCap] 해외주식 완료: {}/{} 종목 업데이트", updated, pairs.size());
+    }
+
+    @Transactional
+    public void saveDomesticMarketCap(String stockCode, Long cap) {
+        instrumentRepository.updateMarketCapByStockCode(stockCode, cap);
+    }
+
+    @Transactional
+    public void saveForeignMarketCap(String stockCode, Long cap) {
+        instrumentRepository.updateMarketCapByForeignStockCode(stockCode, cap);
     }
 }

--- a/src/main/resources/db/migration/V14__alter_instruments_add_market_cap.sql
+++ b/src/main/resources/db/migration/V14__alter_instruments_add_market_cap.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instruments ADD market_cap NUMBER(19,0);


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용

- V14 마이그레이션: `instruments` 테이블에 `market_cap` 컬럼 추가
- `Instrument` 엔티티에 `marketCap` 필드 매핑
- `MarketCapInitializer` 추가: 서버 기동 시 시가총액 일괄 초기화
  - 국내주식: LS API `getFinance()` → 억원 단위로 저장
  - 해외주식: LS API `getInfo()` → `shareprc(USD) × exrate ÷ 1억` 으로 억원 환산
  - `app.market.cap.domestic.skip=true` 옵션으로 국내 스킵 가능
  - `market_cap IS NULL` 종목만 처리하여 이어서 실행 가능
- 종목 검색 정렬 개선: KOSPI/KOSDAQ/해외 시장 구분 제거 → 시가총액 내림차순으로 통일

### 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> `MarketCapInitializer`는 `app.market.cap.enabled=true` 일 때만 실행됩니다. 해외주식 수천 종목 처리 시 API 레이트 리밋으로 상당 시간 소요될 수 있습니다 (1.1초 딜레이).