### PR TITLE
fix(news): 뉴스 publishedAt 타임존 UTC로 수정

### DIFF
--- a/src/main/java/com/sollite/news/domain/entity/StockNewsDocument.java
+++ b/src/main/java/com/sollite/news/domain/entity/StockNewsDocument.java
@@ -51,4 +51,7 @@ public class StockNewsDocument {
 
     @Field("published_at")
     private Date publishedAt;
+
+    @Field("fetched_at")
+    private Date fetchedAt;
 }

--- a/src/main/java/com/sollite/news/dto/NewsDetailResponse.java
+++ b/src/main/java/com/sollite/news/dto/NewsDetailResponse.java
@@ -41,7 +41,7 @@ public record NewsDetailResponse(
                 doc.getStockIndex(),
                 doc.getPublishedAt() != null
                         ? doc.getPublishedAt().toInstant()
-                                .atZone(ZoneId.of("Asia/Seoul"))
+                                .atZone(ZoneId.of("UTC"))
                                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
                         : null
         );

--- a/src/main/java/com/sollite/news/dto/NewsResponse.java
+++ b/src/main/java/com/sollite/news/dto/NewsResponse.java
@@ -50,7 +50,7 @@ public record NewsResponse(
                 doc.getStockIndex(),
                 doc.getPublishedAt() != null
                         ? doc.getPublishedAt().toInstant()
-                                .atZone(ZoneId.of("Asia/Seoul"))
+                                .atZone(ZoneId.of("UTC"))
                                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
                         : null,
                 contentPreview

--- a/src/main/java/com/sollite/news/dto/StockNewsDetailResponse.java
+++ b/src/main/java/com/sollite/news/dto/StockNewsDetailResponse.java
@@ -37,7 +37,7 @@ public record StockNewsDetailResponse(
                 doc.getMarket(),
                 doc.getPublishedAt() != null
                         ? doc.getPublishedAt().toInstant()
-                                .atZone(ZoneId.of("Asia/Seoul"))
+                                .atZone(ZoneId.of("UTC"))
                                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
                         : null
         );

--- a/src/main/java/com/sollite/news/dto/StockNewsResponse.java
+++ b/src/main/java/com/sollite/news/dto/StockNewsResponse.java
@@ -39,7 +39,7 @@ public record StockNewsResponse(
                 doc.getMarket(),
                 doc.getPublishedAt() != null
                         ? doc.getPublishedAt().toInstant()
-                                .atZone(ZoneId.of("Asia/Seoul"))
+                                .atZone(ZoneId.of("UTC"))
                                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
                         : null
         );


### PR DESCRIPTION
DB에 저장된 한국 시간을 UTC로 변환하지 않고 저장하고 있어서,
API 응답에서 UTC → KST 변환 시 9시간이 더해지는 문제 발생.
publishedAt을 UTC 타임존으로 처리하여 한국 시간으로 올바르게 반환.

### Changes
- StockNewsDocument에 fetched_at 필드 추가
- NewsResponse, NewsDetailResponse, StockNewsResponse, StockNewsDetailResponse의 타임존을 UTC로 수정