### PR TITLE
fix(news): 해외 뉴스 미표시 수정 — stock_index별 최신 조회로 변경

### DIFF
--- a/src/main/java/com/sollite/news/domain/repository/NewsRepository.java
+++ b/src/main/java/com/sollite/news/domain/repository/NewsRepository.java
@@ -14,5 +14,7 @@ public interface NewsRepository extends MongoRepository<NewsDocument, String> {
 
     List<NewsDocument> findByPublishedAtGreaterThanEqualOrderByPublishedAtDesc(Date from, Pageable pageable);
 
+    List<NewsDocument> findByStockIndexOrderByPublishedAtDesc(String stockIndex, Pageable pageable);
+
     Optional<NewsDocument> findByNewsId(String newsId);
 }

--- a/src/main/java/com/sollite/news/domain/repository/NewsRepository.java
+++ b/src/main/java/com/sollite/news/domain/repository/NewsRepository.java
@@ -4,15 +4,10 @@ import com.sollite.news.domain.entity.NewsDocument;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 public interface NewsRepository extends MongoRepository<NewsDocument, String> {
-
-    List<NewsDocument> findAllByOrderByPublishedAtDesc(Pageable pageable);
-
-    List<NewsDocument> findByPublishedAtGreaterThanEqualOrderByPublishedAtDesc(Date from, Pageable pageable);
 
     List<NewsDocument> findByStockIndexOrderByPublishedAtDesc(String stockIndex, Pageable pageable);
 

--- a/src/main/java/com/sollite/news/service/NewsService.java
+++ b/src/main/java/com/sollite/news/service/NewsService.java
@@ -1,6 +1,7 @@
 package com.sollite.news.service;
 
 import com.sollite.global.exception.BusinessException;
+import com.sollite.news.domain.entity.NewsDocument;
 import com.sollite.news.domain.repository.NewsRepository;
 import com.sollite.news.dto.NewsDetailResponse;
 import com.sollite.news.dto.NewsResponse;
@@ -10,10 +11,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Date;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -23,25 +23,13 @@ public class NewsService {
 
     @Transactional(readOnly = true)
     public List<NewsResponse> getLatestNews(int size) {
-        Date todayStart = Date.from(
-                LocalDate.now(ZoneId.of("Asia/Seoul"))
-                        .atStartOfDay(ZoneId.of("Asia/Seoul"))
-                        .toInstant()
-        );
+        List<NewsDocument> krNews = newsRepository
+                .findByStockIndexOrderByPublishedAtDesc("KOSDAQ", PageRequest.of(0, size));
+        List<NewsDocument> usNews = newsRepository
+                .findByStockIndexOrderByPublishedAtDesc("NASDAQ", PageRequest.of(0, size));
 
-        List<NewsResponse> todayNews = newsRepository
-                .findByPublishedAtGreaterThanEqualOrderByPublishedAtDesc(todayStart, PageRequest.of(0, size))
-                .stream()
-                .map(NewsResponse::from)
-                .toList();
-
-        if (!todayNews.isEmpty()) {
-            return todayNews;
-        }
-
-        return newsRepository
-                .findAllByOrderByPublishedAtDesc(PageRequest.of(0, size))
-                .stream()
+        return Stream.concat(krNews.stream(), usNews.stream())
+                .sorted(Comparator.comparing(NewsDocument::getPublishedAt).reversed())
                 .map(NewsResponse::from)
                 .toList();
     }

--- a/src/main/java/com/sollite/news/service/NewsService.java
+++ b/src/main/java/com/sollite/news/service/NewsService.java
@@ -23,13 +23,16 @@ public class NewsService {
 
     @Transactional(readOnly = true)
     public List<NewsResponse> getLatestNews(int size) {
-        List<NewsDocument> krNews = newsRepository
+        List<NewsDocument> kospiNews = newsRepository
+                .findByStockIndexOrderByPublishedAtDesc("KOSPI", PageRequest.of(0, size));
+        List<NewsDocument> kosdaqNews = newsRepository
                 .findByStockIndexOrderByPublishedAtDesc("KOSDAQ", PageRequest.of(0, size));
         List<NewsDocument> usNews = newsRepository
                 .findByStockIndexOrderByPublishedAtDesc("NASDAQ", PageRequest.of(0, size));
 
-        return Stream.concat(krNews.stream(), usNews.stream())
+        return Stream.concat(Stream.concat(kospiNews.stream(), kosdaqNews.stream()), usNews.stream())
                 .sorted(Comparator.comparing(NewsDocument::getPublishedAt).reversed())
+                .limit(size)
                 .map(NewsResponse::from)
                 .toList();
     }


### PR DESCRIPTION
## 작업 내용

- `NewsRepository`에 `findByStockIndexOrderByPublishedAtDesc` 메서드 추가
- `NewsService.getLatestNews()`를 날짜 기준 단일 조회에서 `stock_index`별 최신 조회 후 병합 방식으로 변경

## 원인

기존 로직은 오늘 날짜 이후 뉴스를 한꺼번에 조회하여, NASDAQ 뉴스가 전날 KST 기준으로 크롤링된 경우 날짜 필터에서 제외되어 해외 탭에 뉴스가 표시되지 않는 문제가 있었음.

NASDAQ은 한국 시간 기준 새벽에 마감되므로 크롤링 시각이 구조적으로 국내보다 늦어 타이밍 차이 발생.

## 확인 방법

- `GET /api/news?size=10` 응답에 `stockIndex: "NASDAQ"` 항목 포함 여부 확인
- 프론트엔드 오늘의 시황 위젯 해외 탭에 뉴스 표시 여부 확인

closes #68