### PR TITLE
fix(widget): 대시보드 페이지 개수 제한 제거

### DIFF
--- a/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
+++ b/src/main/java/com/sollite/widget/dto/DashboardSaveRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public record DashboardSaveRequest(
         @NotNull(message = "pages는 필수입니다")
-        @Size(min = 1, max = 5, message = "페이지는 1개 이상 5개 이하여야 합니다")
+        @Size(min = 1, message = "페이지는 1개 이상이어야 합니다")
         @Valid
         List<DashboardPageRequest> pages
 ) {}

--- a/src/main/java/com/sollite/widget/exception/WidgetErrorCode.java
+++ b/src/main/java/com/sollite/widget/exception/WidgetErrorCode.java
@@ -8,8 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WidgetErrorCode implements ErrorCode {
 
-    DUPLICATE_PAGE_ORDER(400, "pageOrder 중복 값이 존재합니다"),
-    PAGE_LIMIT_EXCEEDED(400, "대시보드 페이지는 최대 5개까지 생성할 수 있습니다");
+    DUPLICATE_PAGE_ORDER(400, "pageOrder 중복 값이 존재합니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/widget/service/DashboardService.java
+++ b/src/main/java/com/sollite/widget/service/DashboardService.java
@@ -30,7 +30,6 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class DashboardService {
 
-    private static final int MAX_PAGES = 5;
     private static final String STOCK_CHART_TYPE = "stock-chart";
     private static final String STOCK_NEWS_TYPE = "stock-news";
 
@@ -96,9 +95,6 @@ public class DashboardService {
         StockRankingItem topMarketCapStock = marketService.getTopMarketCapStock(request.theme());
 
         List<Dashboard> existing = dashboardRepository.findAllByUserIdWithWidgets(userId);
-        if (existing.size() >= MAX_PAGES) {
-            throw new BusinessException(WidgetErrorCode.PAGE_LIMIT_EXCEEDED);
-        }
 
         int[] stockIdx = {0};
         List<WidgetLayoutRequest> filledWidgets = request.widgets().stream()


### PR DESCRIPTION
## 작업 내용

- `DashboardSaveRequest`: `@Size(max = 5)` 제약 제거
- `DashboardService`: `MAX_PAGES` 상수 및 `PAGE_LIMIT_EXCEEDED` 예외 처리 제거
- `WidgetErrorCode`: `PAGE_LIMIT_EXCEEDED` 에러 코드 제거

## 확인 방법

- 페이지를 5개 초과로 추가 후 저장 API 정상 응답 확인

closes #70