### PR TITLE
feat(kis): 해외 시세·순위 조회 및 토큰 연동 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Java 17 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle 빌드
+        run: ./gradlew bootJar -x test
+
+      - name: AWS 자격증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: 배포 패키지 S3 업로드
+        run: |
+          aws deploy push \
+            --application-name SolLite-Backend \
+            --s3-location s3://sollite-codedeploy-artifacts/deploy-${{ github.sha }}.zip \
+            --source .
+
+      - name: CodeDeploy 배포 시작
+        run: |
+          aws deploy create-deployment \
+            --application-name SolLite-Backend \
+            --deployment-group-name SolLite-Backend-DG \
+            --s3-location bucket=sollite-codedeploy-artifacts,key=deploy-${{ github.sha }}.zip,bundleType=zip \
+            --description "Release ${{ github.sha }}"

--- a/src/main/java/com/sollite/foreignmarket/controller/ForeignStockMarketController.java
+++ b/src/main/java/com/sollite/foreignmarket/controller/ForeignStockMarketController.java
@@ -2,17 +2,32 @@ package com.sollite.foreignmarket.controller;
 
 import com.sollite.foreignmarket.dto.*;
 import com.sollite.foreignmarket.service.ForeignStockMarketService;
+import com.sollite.foreignmarket.service.KisForeignRankingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/market/foreign-stocks")
 @RequiredArgsConstructor
 public class ForeignStockMarketController {
     private final ForeignStockMarketService foreignStockMarketService;
+    private final KisForeignRankingService kisForeignRankingService;
+
+    /**
+     * 해외주식 순위 조회
+     * @param type trading-value(거래대금) | trading-volume(거래량) | rising(상승) | falling(하락) | market-cap(시가총액)
+     * @param exchange NAS | NYS | all
+     */
+    @GetMapping("/ranking")
+    public ResponseEntity<List<ForeignStockRankingItem>> getRanking(
+            @RequestParam(defaultValue = "trading-value") String type,
+            @RequestParam(defaultValue = "NAS") String exchange) {
+        return ResponseEntity.ok(kisForeignRankingService.getRanking(type, exchange));
+    }
 
     /**
      * g3101 - 해외주식 현재가 조회
@@ -101,8 +116,9 @@ public class ForeignStockMarketController {
     public ResponseEntity<ForeignMinuteChartResponse> getMinuteChart(
             @PathVariable String stockCode,
             @RequestParam String exchcd,
-            @RequestParam int nmin) {
-        ForeignMinuteChartResponse response = foreignStockMarketService.getMinuteChart(stockCode, exchcd, nmin);
+            @RequestParam int nmin,
+            @RequestParam(required = false) Integer limit) {
+        ForeignMinuteChartResponse response = foreignStockMarketService.getMinuteChart(stockCode, exchcd, nmin, limit);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/sollite/foreignmarket/controller/InvestTestController.java
+++ b/src/main/java/com/sollite/foreignmarket/controller/InvestTestController.java
@@ -1,0 +1,75 @@
+package com.sollite.foreignmarket.controller;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sollite.global.service.KisTokenService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/invest")
+public class InvestTestController {
+
+    private final WebClient kisWebClient;
+    private final KisTokenService kisTokenService;
+
+    public InvestTestController(
+            @Qualifier("kisWebClient") WebClient kisWebClient,
+            KisTokenService kisTokenService) {
+        this.kisWebClient = kisWebClient;
+        this.kisTokenService = kisTokenService;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Output1(String rsym, String zdiv, String stim, String etim, String next, String nrec) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Output2(String tymd, String xymd, String xhms, String kymd, String khms,
+                   String open, String high, String low, String last, String evol, String eamt) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record KisNminResponse(String rt_cd, String msg_cd, String msg1, Output1 output1, List<Output2> output2) {}
+
+    /**
+     * KIS 해외주식 분봉 조회 테스트
+     * GET /invest?symb=AVGO&excd=NAS&nmin=1&nrec=30
+     */
+    @GetMapping
+    public KisNminResponse getNminChart(
+            @RequestParam(defaultValue = "AVGO") String symb,
+            @RequestParam(defaultValue = "NAS") String excd,
+            @RequestParam(defaultValue = "1") String nmin,
+            @RequestParam(defaultValue = "30") String nrec) {
+
+        String token = kisTokenService.getAccessToken();
+
+        log.info("[InvestTest] KIS 분봉 조회: symb={}, excd={}, nmin={}, nrec={}", symb, excd, nmin, nrec);
+
+        return kisWebClient.get()
+                .uri(u -> u.path("/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice")
+                        .queryParam("AUTH", "")
+                        .queryParam("EXCD", excd)
+                        .queryParam("SYMB", symb)
+                        .queryParam("NMIN", nmin)
+                        .queryParam("PINC", "1")
+                        .queryParam("NEXT", "")
+                        .queryParam("NREC", nrec)
+                        .queryParam("FILL", "")
+                        .queryParam("KEYB", "")
+                        .build())
+                .header("authorization", "Bearer " + token)
+                .header("tr_id", "HHDFS76950200")
+                .header("custtype", "P")
+                .header("content-type", "application/json; charset=utf-8")
+                .retrieve()
+                .bodyToMono(KisNminResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/sollite/foreignmarket/dto/ForeignStockRankingItem.java
+++ b/src/main/java/com/sollite/foreignmarket/dto/ForeignStockRankingItem.java
@@ -1,0 +1,20 @@
+package com.sollite.foreignmarket.dto;
+
+public record ForeignStockRankingItem(
+        int rank,
+        String stockCode,     // 종목코드 (AAPL, TSLA 등)
+        String exchangeCode,  // 거래소코드 (NAS / NYS)
+        String name,          // 한글종목명
+        String nameEn,        // 영문종목명
+        double price,         // 현재가
+        String sign,          // 등락 기호
+        double change,        // 전일대비
+        double changeRate,    // 등락률
+        long volume,          // 거래량
+        Long tradingValue,       // 거래대금 (trading-value 타입)
+        Long avgTradingValue,    // 평균 거래대금 (trading-value secondary)
+        Long avgVolume,          // 평균 거래량 (trading-volume secondary)
+        Long marketCap,          // 시가총액 (market-cap 타입, USD)
+        Double marketShareRate   // 시장비중 (market-cap 타입, %)
+) {
+}

--- a/src/main/java/com/sollite/foreignmarket/dto/KisRankingResponse.java
+++ b/src/main/java/com/sollite/foreignmarket/dto/KisRankingResponse.java
@@ -1,0 +1,39 @@
+package com.sollite.foreignmarket.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KisRankingResponse(
+        String rt_cd,
+        String msg_cd,
+        String msg1,
+        Output1 output1,
+        List<Output2> output2
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Output1(String zdiv, String stat, String nrec) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Output2(
+            String rsym,
+            String excd,
+            String symb,
+            @JsonAlias("knam") String name,   // 거래량/거래대금/상승하락/시총: name, 급등락: knam
+            String last,
+            String sign,
+            String diff,
+            String rate,
+            String tvol,
+            String tamt,                       // 거래대금
+            String a_tamt,                     // 평균거래대금 (거래대금 순위)
+            String a_tvol,                     // 평균거래량 (거래량 순위)
+            String tomv,                       // 시가총액 (시가총액 순위)
+            String grav,                       // 시장비중 (시가총액 순위)
+            String rank,
+            @JsonAlias("enam") String ename,  // 거래량/거래대금/상승하락/시총: ename, 급등락: enam
+            String e_ordyn
+    ) {}
+}

--- a/src/main/java/com/sollite/foreignmarket/service/ForeignStockMarketService.java
+++ b/src/main/java/com/sollite/foreignmarket/service/ForeignStockMarketService.java
@@ -57,6 +57,8 @@ public interface ForeignStockMarketService {
      */
     ForeignMinuteChartResponse getMinuteChart(String stockCode, String exchcd, int nmin);
 
+    ForeignMinuteChartResponse getMinuteChart(String stockCode, String exchcd, int nmin, Integer limit);
+
     /**
      * g3204 - 해외주식 차트일주월년별 조회
      * @param stockCode 종목코드 (TSLA, NVDA 등)

--- a/src/main/java/com/sollite/foreignmarket/service/KisForeignMinuteChartService.java
+++ b/src/main/java/com/sollite/foreignmarket/service/KisForeignMinuteChartService.java
@@ -1,0 +1,197 @@
+package com.sollite.foreignmarket.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sollite.foreignmarket.dto.ForeignMinuteChartResponse;
+import com.sollite.foreignmarket.exception.ForeignStockErrorCode;
+import com.sollite.global.exception.BusinessException;
+import com.sollite.global.service.KisTokenService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Slf4j
+@Service
+public class KisForeignMinuteChartService {
+
+    private static final int KIS_MAX_PER_REQUEST = 120;
+    private static final int FOREIGN_SESSION_MINUTES = 390;
+    private static final String RATE_LIMIT_CODE = "EGW00201";
+    private static final int RATE_LIMIT_MAX_RETRIES = 3;
+    private static final long RATE_LIMIT_DELAY_MS = 1000;
+    private static final long PAGE_DELAY_MS = 300;
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HHmmss");
+    private static final ZoneId NY = ZoneId.of("America/New_York");
+
+    private final WebClient kisWebClient;
+    private final KisTokenService kisTokenService;
+
+    public KisForeignMinuteChartService(
+            @Qualifier("kisWebClient") WebClient kisWebClient,
+            KisTokenService kisTokenService) {
+        this.kisWebClient = kisWebClient;
+        this.kisTokenService = kisTokenService;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Output1(String next) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Output2(String xymd, String xhms,
+                   String open, String high, String low, String last, String evol, String eamt) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record KisNminResponse(String rt_cd, String msg1, Output1 output1, List<Output2> output2) {}
+
+    public ForeignMinuteChartResponse getMinuteChart(String symbol, String exchcd, int nmin, Integer limit) {
+        try {
+            String kisExcd = toKisExcd(exchcd);
+            int maxPoints = (limit != null && limit > 0) ? limit : calculateTargetPoints(nmin);
+
+            List<ForeignMinuteChartResponse.MinuteChartDataPoint> dataPoints = new ArrayList<>();
+            String keyb = "";
+            boolean hasNext = true;
+
+            while (dataPoints.size() < maxPoints && hasNext) {
+                int nrec = Math.min(KIS_MAX_PER_REQUEST, maxPoints - dataPoints.size());
+                KisNminResponse res = callKis(symbol, kisExcd, String.valueOf(nmin), String.valueOf(nrec), keyb);
+
+                if (res == null || !"0".equals(res.rt_cd())) {
+                    log.warn("[KisMinuteChart] API 오류: symbol={}, rt_cd={}, msg={}", symbol,
+                            res != null ? res.rt_cd() : "null", res != null ? res.msg1() : "null");
+                    throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
+                }
+
+                List<Output2> page = res.output2() != null ? res.output2() : List.of();
+                for (Output2 item : page) {
+                    dataPoints.add(toDataPoint(item));
+                }
+
+                hasNext = "1".equals(res.output1() != null ? res.output1().next() : "0") && !page.isEmpty();
+                if (hasNext) {
+                    Output2 last = page.get(page.size() - 1);
+                    keyb = last.xymd() + shiftMinutes(last.xhms(), nmin);
+                    sleepQuietly(PAGE_DELAY_MS);
+                }
+            }
+
+            log.info("[KisMinuteChart] 조회 완료: symbol={}, excd={}, nmin={}, points={}", symbol, kisExcd, nmin, dataPoints.size());
+            return new ForeignMinuteChartResponse(symbol, nmin, dataPoints);
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() == 401) {
+                log.warn("[KisMinuteChart] 토큰 만료(401), 재발급 후 재시도: symbol={}", symbol);
+                kisTokenService.invalidateToken();
+                return getMinuteChart(symbol, exchcd, nmin, limit);
+            }
+            log.error("[KisMinuteChart] HTTP 오류: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
+        } catch (Exception e) {
+            log.error("[KisMinuteChart] 예외 발생: symbol={}", symbol, e);
+            throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
+        }
+    }
+
+    private KisNminResponse callKis(String symb, String excd, String nmin, String nrec, String keyb) {
+        return callKis(symb, excd, nmin, nrec, keyb, 0);
+    }
+
+    private KisNminResponse callKis(String symb, String excd, String nmin, String nrec, String keyb, int retryCount) {
+        String token = kisTokenService.getAccessToken();
+        try {
+            return kisWebClient.get()
+                    .uri(u -> u.path("/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice")
+                            .queryParam("AUTH", "")
+                            .queryParam("EXCD", excd)
+                            .queryParam("SYMB", symb)
+                            .queryParam("NMIN", nmin)
+                            .queryParam("PINC", "1")
+                            .queryParam("NEXT", keyb.isBlank() ? "" : "1")
+                            .queryParam("NREC", nrec)
+                            .queryParam("FILL", "")
+                            .queryParam("KEYB", keyb)
+                            .build())
+                    .header("authorization", "Bearer " + token)
+                    .header("tr_id", "HHDFS76950200")
+                    .header("custtype", "P")
+                    .header("content-type", "application/json; charset=utf-8")
+                    .retrieve()
+                    .bodyToMono(KisNminResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            if (retryCount < RATE_LIMIT_MAX_RETRIES && e.getResponseBodyAsString().contains(RATE_LIMIT_CODE)) {
+                long delay = RATE_LIMIT_DELAY_MS * (retryCount + 1);
+                log.warn("[KisMinuteChart] 초당 거래건수 초과, {}ms 후 재시도 ({}/{}): symb={}", delay, retryCount + 1, RATE_LIMIT_MAX_RETRIES, symb);
+                sleepQuietly(delay);
+                return callKis(symb, excd, nmin, nrec, keyb, retryCount + 1);
+            }
+            throw e;
+        }
+    }
+
+    private void sleepQuietly(long millis) {
+        try { Thread.sleep(millis); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+
+    private ForeignMinuteChartResponse.MinuteChartDataPoint toDataPoint(Output2 item) {
+        LocalDate date = LocalDate.parse(item.xymd(), DATE_FMT);
+        LocalTime time = LocalTime.parse(item.xhms(), TIME_FMT);
+        long epochMilli = LocalDateTime.of(date, time).atZone(NY).toInstant().toEpochMilli();
+
+        return new ForeignMinuteChartResponse.MinuteChartDataPoint(
+                epochMilli,
+                parseDouble(item.open()),
+                parseDouble(item.high()),
+                parseDouble(item.low()),
+                parseDouble(item.last()),
+                parseLong(item.evol()),
+                parseLong(item.eamt())
+        );
+    }
+
+    private String shiftMinutes(String xhms, int nmin) {
+        try {
+            return LocalTime.parse(xhms, TIME_FMT).minusMinutes(nmin).format(TIME_FMT);
+        } catch (Exception e) {
+            return xhms;
+        }
+    }
+
+    private String toKisExcd(String exchcd) {
+        if (exchcd == null) return "NAS";
+        return switch (exchcd.trim().toUpperCase(Locale.ROOT)) {
+            case "82", "NAS", "NASDAQ" -> "NAS";
+            case "81", "NYS", "NYSE"   -> "NYS";
+            case "AMS", "AMEX"         -> "AMS";
+            default                    -> exchcd.trim();
+        };
+    }
+
+    private int calculateTargetPoints(int nmin) {
+        int interval = Math.max(nmin, 1);
+        return (int) Math.ceil((double) FOREIGN_SESSION_MINUTES / interval) + 10;
+    }
+
+    private double parseDouble(String v) {
+        if (v == null || v.isBlank()) return 0.0;
+        try { return Double.parseDouble(v.trim()); } catch (NumberFormatException e) { return 0.0; }
+    }
+
+    private long parseLong(String v) {
+        if (v == null || v.isBlank()) return 0L;
+        try { return Long.parseLong(v.trim()); } catch (NumberFormatException e) { return 0L; }
+    }
+}

--- a/src/main/java/com/sollite/foreignmarket/service/KisForeignRankingService.java
+++ b/src/main/java/com/sollite/foreignmarket/service/KisForeignRankingService.java
@@ -1,0 +1,223 @@
+package com.sollite.foreignmarket.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sollite.foreignmarket.dto.ForeignStockRankingItem;
+import com.sollite.foreignmarket.dto.KisRankingResponse;
+import com.sollite.foreignmarket.exception.ForeignStockErrorCode;
+import com.sollite.global.exception.BusinessException;
+import com.sollite.global.service.KisTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class KisForeignRankingService {
+
+    private final WebClient kisWebClient;
+    private final KisTokenService kisTokenService;
+    private final ObjectMapper objectMapper;
+
+    public KisForeignRankingService(
+            @Qualifier("kisWebClient") WebClient kisWebClient,
+            KisTokenService kisTokenService,
+            ObjectMapper objectMapper) {
+        this.kisWebClient = kisWebClient;
+        this.kisTokenService = kisTokenService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Cacheable(cacheNames = "foreign:ranking", key = "#type + ':' + #exchange", sync = true)
+    public List<ForeignStockRankingItem> getRanking(String type, String exchange) {
+        try {
+            String resolvedExchange = "all".equalsIgnoreCase(exchange) ? "NAS" : exchange.toUpperCase();
+            return fetchRanking(type, resolvedExchange);
+        } catch (WebClientResponseException e) {
+            log.error(
+                    "해외주식 순위 KIS 응답 오류: type={}, exchange={}, status={}, body={}",
+                    type,
+                    exchange,
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString(),
+                    e
+            );
+            throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("해외주식 순위 조회 중 예외 발생: type={}, exchange={}", type, exchange, e);
+            throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
+        }
+    }
+
+    private List<ForeignStockRankingItem> fetchRanking(String type, String excd) throws Exception {
+        String token = kisTokenService.getAccessToken();
+        String raw = switch (type) {
+            case "trading-volume" -> callTradeVol(token, excd);
+            case "rising"         -> callUpdownRate(token, excd, "1");
+            case "falling"        -> callUpdownRate(token, excd, "0");
+            case "market-cap"     -> callMarketCap(token, excd);
+            default               -> callTradePbmn(token, excd);  // trading-value
+        };
+
+        KisRankingResponse res = objectMapper.readValue(raw, KisRankingResponse.class);
+        if (res == null || res.output2() == null) {
+            throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
+        }
+
+        return res.output2().stream()
+                .limit(50)
+                .map(item -> toRankingItem(item, type))
+                .toList();
+    }
+
+    private ForeignStockRankingItem toRankingItem(KisRankingResponse.Output2 item, String type) {
+        int rank = parseIntSafe(item.rank());
+        double price = parseDoubleSafe(item.last());
+        double change = parseDoubleSafe(item.diff());
+        double changeRate = parseDoubleSafe(item.rate());
+        long volume = parseLongSafe(item.tvol());
+
+        Long tradingValue    = "trading-value".equals(type) ? parseLongSafe(item.tamt())  : null;
+        Long avgTradingValue = "trading-value".equals(type) ? parseLongSafe(item.a_tamt()) : null;
+        Long avgVolume       = "trading-volume".equals(type) ? parseLongSafe(item.a_tvol()) : null;
+        Long marketCap       = "market-cap".equals(type)    ? parseLongSafe(item.tomv())  : null;
+        Double marketShareRate = "market-cap".equals(type)  ? parseDoubleSafe(item.grav()) : null;
+
+        return new ForeignStockRankingItem(
+                rank,
+                item.symb(),
+                item.excd(),
+                item.name(),
+                item.ename(),
+                price,
+                item.sign(),
+                change,
+                changeRate,
+                volume,
+                tradingValue,
+                avgTradingValue,
+                avgVolume,
+                marketCap,
+                marketShareRate
+        );
+    }
+
+    // ── KIS API 호출 ──────────────────────────────────────────────
+
+    private String callTradePbmn(String token, String excd) {
+        // 해외주식 거래대금순위 [해외주식-044] HHDFS76320010
+        return kisWebClient.get()
+                .uri(u -> u.path("/uapi/overseas-stock/v1/ranking/trade-pbmn")
+                        .queryParam("KEYB", "")
+                        .queryParam("AUTH", "")
+                        .queryParam("EXCD", excd)
+                        .queryParam("NDAY", "0")
+                        .queryParam("VOL_RANG", "0")
+                        .queryParam("PRC1", "")
+                        .queryParam("PRC2", "")
+                        .build())
+                .header("authorization", "Bearer " + token)
+                .header("tr_id", "HHDFS76320010")
+                .header("custtype", "P")
+                .header("content-type", "application/json; charset=utf-8")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    private String callTradeVol(String token, String excd) {
+        // 해외주식 거래량순위 [해외주식-043] HHDFS76310010
+        return kisWebClient.get()
+                .uri(u -> u.path("/uapi/overseas-stock/v1/ranking/trade-vol")
+                        .queryParam("KEYB", "")
+                        .queryParam("AUTH", "")
+                        .queryParam("EXCD", excd)
+                        .queryParam("NDAY", "0")
+                        .queryParam("VOL_RANG", "0")
+                        .queryParam("PRC1", "")
+                        .queryParam("PRC2", "")
+                        .build())
+                .header("authorization", "Bearer " + token)
+                .header("tr_id", "HHDFS76310010")
+                .header("custtype", "P")
+                .header("content-type", "application/json; charset=utf-8")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    private String callUpdownRate(String token, String excd, String gubn) {
+        // 해외주식 상승율/하락율 [해외주식-041] HHDFS76290000
+        return kisWebClient.get()
+                .uri(u -> u.path("/uapi/overseas-stock/v1/ranking/updown-rate")
+                        .queryParam("KEYB", "")
+                        .queryParam("AUTH", "")
+                        .queryParam("EXCD", excd)
+                        .queryParam("GUBN", gubn)
+                        .queryParam("NDAY", "0")
+                        .queryParam("VOL_RANG", "0")
+                        .build())
+                .header("authorization", "Bearer " + token)
+                .header("tr_id", "HHDFS76290000")
+                .header("custtype", "P")
+                .header("content-type", "application/json; charset=utf-8")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    private String callMarketCap(String token, String excd) {
+        // 해외주식 시가총액순위 [해외주식-047] HHDFS76350100
+        return kisWebClient.get()
+                .uri(u -> u.path("/uapi/overseas-stock/v1/ranking/market-cap")
+                        .queryParam("KEYB", "")
+                        .queryParam("AUTH", "")
+                        .queryParam("EXCD", excd)
+                        .queryParam("CURR_GB", "0")
+                        .queryParam("VOL_RANG", "0")
+                        .build())
+                .header("authorization", "Bearer " + token)
+                .header("tr_id", "HHDFS76350100")
+                .header("custtype", "P")
+                .header("content-type", "application/json; charset=utf-8")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    // ── 파싱 헬퍼 ─────────────────────────────────────────────────
+
+    private double parseDoubleSafe(String value) {
+        if (value == null || value.isBlank()) return 0.0;
+        try {
+            return Double.parseDouble(value.replace("+", "").trim());
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+
+    private long parseLongSafe(String value) {
+        if (value == null || value.isBlank()) return 0L;
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private int parseIntSafe(String value) {
+        if (value == null || value.isBlank()) return 0;
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/sollite/foreignmarket/service/LsForeignStockMarketServiceImpl.java
+++ b/src/main/java/com/sollite/foreignmarket/service/LsForeignStockMarketServiceImpl.java
@@ -36,6 +36,7 @@ class LsForeignStockMarketServiceImpl implements ForeignStockMarketService {
     private final WebClient lsWebClient;
     private final LsTokenService tokenService;
     private final ObjectMapper objectMapper;
+    private final KisForeignMinuteChartService kisMinuteChartService;
     @Value("${ls.api.mac-address:}")
     private String configuredMacAddress;
     private static final String INITIAL_TR_CONT_KEY = "";
@@ -528,55 +529,12 @@ class LsForeignStockMarketServiceImpl implements ForeignStockMarketService {
             sync = true
     )
     public ForeignMinuteChartResponse getMinuteChart(String stockCode, String exchcd, int nmin) {
-        return getMinuteChart(stockCode, exchcd, nmin, false);
+        return kisMinuteChartService.getMinuteChart(stockCode, exchcd, nmin, null);
     }
 
-    private ForeignMinuteChartResponse getMinuteChart(String stockCode, String exchcd, int nmin, boolean isRetry) {
-        try {
-            String normalizedStockCode = normalizeStockCode(stockCode);
-            String normalizedExchcd = normalizeExchangeCode(exchcd);
-            String keysymbol = buildKeysymbol(normalizedStockCode, normalizedExchcd);
-            List<LsG3203Res.G3203OutBlock1> rawList = fetchMinuteChartPages(
-                    stockCode,
-                    exchcd,
-                    normalizedExchcd,
-                    normalizedStockCode,
-                    keysymbol,
-                    nmin
-            );
-
-            ZoneId ny = ZoneId.of("America/New_York");
-            List<ForeignMinuteChartResponse.MinuteChartDataPoint> dataPoints = rawList.stream()
-                    .map(item -> new ForeignMinuteChartResponse.MinuteChartDataPoint(
-                            LocalDateTime.of(
-                                    LocalDate.parse(item.date(), DATE_FMT),
-                                    java.time.LocalTime.parse(item.loctime(), TIME_FMT)
-                            ).atZone(ny).toInstant().toEpochMilli(),
-                            parseDouble(item.open()),
-                            parseDouble(item.high()),
-                            parseDouble(item.low()),
-                            parseDouble(item.close()),
-                            parseLong(item.exevol()),
-                            parseLong(item.amount())
-                    ))
-                    .toList();
-
-            return new ForeignMinuteChartResponse(stockCode, nmin, dataPoints);
-
-        } catch (BusinessException e) {
-            throw e;
-        } catch (WebClientResponseException e) {
-            if (!isRetry && e.getStatusCode().value() == 401) {
-                log.warn("토큰 만료 감지 (401), 재발급 후 재시도: stockCode={}", stockCode);
-                tokenService.invalidateToken();
-                return getMinuteChart(stockCode, exchcd, nmin, true);
-            }
-            log.error("LS증권 API 호출 실패. HTTP 상태: {}, 응답: {}", e.getStatusCode(), e.getResponseBodyAsString());
-            throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
-        } catch (Exception e) {
-            log.error("해외주식 분차트 조회 중 예외 발생: stockCode={}", stockCode, e);
-            throw new BusinessException(ForeignStockErrorCode.FOREIGN_STOCK_API_ERROR);
-        }
+    @Override
+    public ForeignMinuteChartResponse getMinuteChart(String stockCode, String exchcd, int nmin, Integer limit) {
+        return kisMinuteChartService.getMinuteChart(stockCode, exchcd, nmin, limit);
     }
 
     private List<LsG3203Res.G3203OutBlock1> fetchMinuteChartPages(
@@ -585,7 +543,8 @@ class LsForeignStockMarketServiceImpl implements ForeignStockMarketService {
             String normalizedExchcd,
             String normalizedStockCode,
             String keysymbol,
-            int nmin
+            int nmin,
+            Integer limit
     ) throws Exception {
         LocalDate today = LocalDate.now(ZoneId.of("America/New_York"));
         DayOfWeek dow = today.getDayOfWeek();
@@ -597,7 +556,7 @@ class LsForeignStockMarketServiceImpl implements ForeignStockMarketService {
         String ctsTime = "";
         String trContKey = INITIAL_TR_CONT_KEY;
         boolean continued = false;
-        int maxPoints = calculateMinuteChartTargetPoints(nmin);
+        int maxPoints = (limit != null && limit > 0) ? limit : calculateMinuteChartTargetPoints(nmin);
         int requestCount = 0;
 
         while (deduplicated.size() < maxPoints && requestCount < MAX_MINUTE_CHART_REQUESTS) {

--- a/src/main/java/com/sollite/global/config/CacheConfig.java
+++ b/src/main/java/com/sollite/global/config/CacheConfig.java
@@ -65,7 +65,9 @@ public class CacheConfig {
                 Map.entry("foreign:tick-chart",     base.entryTtl(Duration.ofSeconds(30))),
                 Map.entry("foreign:minute-chart",   base.entryTtl(Duration.ofSeconds(30))),
                 Map.entry("foreign:advanced-chart", base.entryTtl(Duration.ofMinutes(5))),
-                Map.entry("foreign:info",           base.entryTtl(Duration.ofHours(24)))
+                Map.entry("foreign:info",           base.entryTtl(Duration.ofHours(24))),
+                // 해외주식 순위
+                Map.entry("foreign:ranking",        base.entryTtl(Duration.ofMinutes(1)))
         );
 
         return RedisCacheManager.builder(connectionFactory)

--- a/src/main/java/com/sollite/global/config/WebClientConfig.java
+++ b/src/main/java/com/sollite/global/config/WebClientConfig.java
@@ -17,6 +17,15 @@ public class WebClientConfig {
     @Value("${ls.api.appsecret}")
     private String appSecret;
 
+    @Value("${kis.api.url}")
+    private String kisBaseUrl;
+
+    @Value("${kis.api.appkey}")
+    private String kisAppKey;
+
+    @Value("${kis.api.appsecret}")
+    private String kisAppSecret;
+
     @Bean
     public WebClient lsWebClient()
     {
@@ -24,6 +33,15 @@ public class WebClientConfig {
                 .baseUrl(baseUrl)
                 .defaultHeader("appkey", appKey)
                 .defaultHeader("appsecret", appSecret)
+                .build();
+    }
+
+    @Bean
+    public WebClient kisWebClient() {
+        return WebClient.builder()
+                .baseUrl(kisBaseUrl)
+                .defaultHeader("appkey", kisAppKey)
+                .defaultHeader("appsecret", kisAppSecret)
                 .build();
     }
 

--- a/src/main/java/com/sollite/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/sollite/global/exception/GlobalErrorCode.java
@@ -9,7 +9,8 @@ public enum GlobalErrorCode implements ErrorCode {
 
     INVALID_INPUT(400, "입력값이 올바르지 않습니다"),
     INTERNAL_ERROR(500, "서버 내부 오류가 발생했습니다"),
-    LS_TOKEN_FETCH_FAILED(502, "LS증권 API 토큰 발급에 실패했습니다");
+    LS_TOKEN_FETCH_FAILED(502, "LS증권 API 토큰 발급에 실패했습니다"),
+    KIS_TOKEN_FETCH_FAILED(502, "한국투자증권 API 토큰 발급에 실패했습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sollite/global/service/KisTokenService.java
+++ b/src/main/java/com/sollite/global/service/KisTokenService.java
@@ -1,0 +1,64 @@
+package com.sollite.global.service;
+
+import com.sollite.global.exception.BusinessException;
+import com.sollite.global.exception.GlobalErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Instant;
+
+@Slf4j
+@Service
+public class KisTokenService {
+
+    private final WebClient kisWebClient;
+
+    @Value("${kis.api.appkey}") private String appKey;
+    @Value("${kis.api.appsecret}") private String appSecret;
+
+    private String cachedToken;
+    private Instant tokenExpiresAt;
+
+    public KisTokenService(@Qualifier("kisWebClient") WebClient kisWebClient) {
+        this.kisWebClient = kisWebClient;
+    }
+
+    public synchronized String getAccessToken() {
+        if (cachedToken == null || tokenExpiresAt == null || Instant.now().isAfter(tokenExpiresAt.minusSeconds(300))) {
+            issueNewToken();
+        }
+        return cachedToken;
+    }
+
+    public synchronized void invalidateToken() {
+        log.info("KIS 토큰 강제 무효화");
+        cachedToken = null;
+        tokenExpiresAt = null;
+    }
+
+    private void issueNewToken() {
+        log.info("KIS 토큰 발급 요청");
+
+        record TokenRequest(String grant_type, String appkey, String appsecret) {}
+        record TokenResponse(String access_token, long expires_in) {}
+
+        TokenResponse response = kisWebClient.post()
+                .uri("/oauth2/tokenP")
+                .header("content-type", "application/json; charset=UTF-8")
+                .bodyValue(new TokenRequest("client_credentials", appKey, appSecret))
+                .retrieve()
+                .bodyToMono(TokenResponse.class)
+                .block();
+
+        if (response == null || response.access_token() == null) {
+            throw new BusinessException(GlobalErrorCode.KIS_TOKEN_FETCH_FAILED);
+        }
+
+        cachedToken = response.access_token();
+        tokenExpiresAt = Instant.now().plusSeconds(response.expires_in());
+        log.info("KIS 토큰 발급 완료, 만료까지 {}초", response.expires_in());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: sol-lite-backend
   profiles:
-    active: local
+    active: ${SPRING_PROFILES_ACTIVE:local}
 
   # ── Oracle (JPA) ──
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -130,6 +130,13 @@ management:
     health:
       show-details: never
 
+# ── Korea Investment Securities API ──
+kis:
+  api:
+    url: "https://openapi.koreainvestment.com:9443"
+    appkey: ${KIS_APPKEY}
+    appsecret: ${KIS_APPSECRET}
+
 # ── LS Securities API  & Websocket ──
 ls:
   api:


### PR DESCRIPTION
## 변경 사항
- KIS 토큰 발급 서비스와 WebClient 설정 추가
- 해외 분봉/순위 조회용 DTO 및 서비스 추가
- 해외 시세 컨트롤러·서비스와 캐시 설정 연동
- release 배포 workflow를 dev 흐름에도 동기화

## 비고
- 백엔드 변경만 포함
- 대상 브랜치: dev