### PR TITLE
fix(notifications): 가격 변동 알림 교착 상태 및 임계값 저장 버그 수정

### DIFF
--- a/src/main/java/com/sollite/global/config/AsyncConfig.java
+++ b/src/main/java/com/sollite/global/config/AsyncConfig.java
@@ -37,6 +37,7 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setRejectedExecutionHandler((r, e) -> {
             log.warn("[PRICE_CHECK] 스레드풀 큐 포화로 가격 체크 이벤트 폐기됨 - activeThreads={}, queueSize={}",
                     e.getActiveCount(), e.getQueue().size());
+            // 예외는 제출 스레드(onPriceChange/processLatest)의 try-catch로 전파됨
             throw new RejectedExecutionException("priceCheckExecutor 포화 - queueSize=" + e.getQueue().size());
         });
         executor.initialize();

--- a/src/main/java/com/sollite/global/config/AsyncConfig.java
+++ b/src/main/java/com/sollite/global/config/AsyncConfig.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 @Slf4j
 @Configuration
@@ -33,9 +34,11 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(4);
         executor.setQueueCapacity(1000);
         executor.setThreadNamePrefix("price-check-");
-        executor.setRejectedExecutionHandler((r, e) ->
-                log.warn("[PRICE_CHECK] 스레드풀 큐 포화로 가격 체크 이벤트 폐기됨 - activeThreads={}, queueSize={}",
-                        e.getActiveCount(), e.getQueue().size()));
+        executor.setRejectedExecutionHandler((r, e) -> {
+            log.warn("[PRICE_CHECK] 스레드풀 큐 포화로 가격 체크 이벤트 폐기됨 - activeThreads={}, queueSize={}",
+                    e.getActiveCount(), e.getQueue().size());
+            throw new RejectedExecutionException("priceCheckExecutor 포화 - queueSize=" + e.getQueue().size());
+        });
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
+++ b/src/main/java/com/sollite/market/domain/repository/InstrumentRepository.java
@@ -113,4 +113,5 @@ public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
             ORDER BY i.instrumentId ASC
             """)
     List<Instrument> findActiveByStockCode(@Param("stockCode") String stockCode);
+
 }

--- a/src/main/java/com/sollite/notifications/controller/NotificationController.java
+++ b/src/main/java/com/sollite/notifications/controller/NotificationController.java
@@ -56,6 +56,16 @@ public class NotificationController {
         return ResponseEntity.noContent().build();
     }
 
+    /** DELETE /api/notifications/{notificationId} — 단건 삭제 */
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<Void> deleteNotification(
+            Authentication authentication,
+            @PathVariable Long notificationId) {
+        Long userId = AuthUtil.getUserId(authentication);
+        notificationService.deleteNotification(userId, notificationId);
+        return ResponseEntity.noContent().build();
+    }
+
     // ── 알림 설정 ─────────────────────────────────────────────────────────
 
     /** GET /api/notifications/settings — 알림 설정 조회 */

--- a/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
@@ -53,7 +53,7 @@ public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
             @Param("todayStart") java.time.LocalDateTime todayStart);
 
     /** 알림 설정 임계값 변경 시 PERCENT 타입 활성 알림만 업데이트 */
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PriceAlert p SET p.thresholdPercent = :threshold " +
            "WHERE p.userId = :userId AND p.activeYn = 'Y' AND p.alertType = 'PERCENT'")
     int updateThresholdByUserId(@Param("userId") Long userId, @Param("threshold") BigDecimal threshold);

--- a/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
+++ b/src/main/java/com/sollite/notifications/domain/repository/PriceAlertRepository.java
@@ -15,15 +15,14 @@ public interface PriceAlertRepository extends JpaRepository<PriceAlert, Long> {
 
     /**
      * 가격 변동 체크 시 사용. 비관적 락으로 동시 트리거 방지.
-     * 호출 전 existsActiveByInstrumentIds()로 사전 확인 후 호출할 것.
+     * 호출 전 existsUntriggeredTodayByInstrumentIds()로 사전 확인 후 호출할 것.
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT p FROM PriceAlert p WHERE p.instrumentId IN :instrumentIds AND p.activeYn = 'Y'")
-    List<PriceAlert> findActiveByInstrumentIdsWithLock(@Param("instrumentIds") List<Long> instrumentIds);
-
-    /** 활성 알림 존재 여부 사전 확인 (락 없이 빠르게 조회) */
-    @Query("SELECT COUNT(p) > 0 FROM PriceAlert p WHERE p.instrumentId IN :instrumentIds AND p.activeYn = 'Y'")
-    boolean existsActiveByInstrumentIds(@Param("instrumentIds") List<Long> instrumentIds);
+    @Query("SELECT p FROM PriceAlert p WHERE p.instrumentId IN :instrumentIds " +
+           "AND p.activeYn = 'Y' AND (p.triggeredAt IS NULL OR p.triggeredAt < :todayStart)")
+    List<PriceAlert> findUntriggeredTodayByInstrumentIdsWithLock(
+            @Param("instrumentIds") List<Long> instrumentIds,
+            @Param("todayStart") java.time.LocalDateTime todayStart);
 
     List<PriceAlert> findByUserIdOrderByCreatedAtDesc(Long userId);
 

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -7,6 +7,7 @@ import com.sollite.notifications.domain.enums.NotificationType;
 import com.sollite.notifications.domain.repository.PriceAlertRepository;
 import com.sollite.notifications.service.ActivePriceAlertRegistry;
 import com.sollite.notifications.service.NotificationSettingService;
+import com.sollite.websocket.service.LsBrokerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,8 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -38,8 +41,8 @@ import java.util.stream.Collectors;
  * 이로써 틱이 빠른 종목에서 큐 적재량을 종목 수 기준으로 억제한다.
  *
  * [동시성]
- * existsActiveByInstrumentIds(락 없이 빠른 사전 확인) →
- * findActiveByInstrumentIdsWithLock(PESSIMISTIC_WRITE으로 중복 트리거 방지)
+ * existsUntriggeredTodayByInstrumentIds(락 없이 빠른 사전 확인) →
+ * findUntriggeredTodayByInstrumentIdsWithLock(PESSIMISTIC_WRITE으로 중복 트리거 방지)
  */
 @Slf4j
 @Component
@@ -51,6 +54,7 @@ public class PriceAlertChecker {
     private final ApplicationEventPublisher eventPublisher;
     private final NotificationSettingService notificationSettingService;
     private final ActivePriceAlertRegistry activePriceAlertRegistry;
+    private final LsBrokerService lsBrokerService;
 
     /**
      * 종목별 최신 틱 이벤트 버퍼.
@@ -89,14 +93,17 @@ public class PriceAlertChecker {
         // instrumentId → 활성 알림 수
         Map<Long, Long> countByInstrumentId = new HashMap<>();
         for (Object[] row : rows) {
-            countByInstrumentId.put((Long) row[0], (Long) row[1]);
+            countByInstrumentId.put(((Number) row[0]).longValue(), ((Number) row[1]).longValue());
         }
+
+        activePriceAlertRegistry.clear();
 
         instrumentRepository.findAllById(countByInstrumentId.keySet()).forEach(instrument -> {
             long count = countByInstrumentId.get(instrument.getInstrumentId());
             for (long i = 0; i < count; i++) {
                 activePriceAlertRegistry.register(instrument.getStockCode());
             }
+            lsBrokerService.subscribeForPriceAlert(instrument.getStockCode(), instrument.getMarketType());
         });
 
         log.info("[PRICE_ALERT] 가격 알림 레지스트리 복구 완료 — 종목 수={}, 총 알림 수={}",
@@ -112,7 +119,12 @@ public class PriceAlertChecker {
     public void onPriceChange(PriceChangeEvent event) {
         latestPending.put(event.symbol(), event);
         if (activeSymbols.add(event.symbol())) {
-            self.processLatest(event.symbol());
+            try {
+                self.processLatest(event.symbol());
+            } catch (Exception e) {
+                activeSymbols.remove(event.symbol());
+                log.warn("[PRICE_ALERT] processLatest 최초 제출 실패 - symbol={}, error={}", event.symbol(), e.getMessage());
+            }
         }
     }
 
@@ -142,7 +154,14 @@ public class PriceAlertChecker {
             activeSymbols.remove(symbol);
             // 처리 중 새 틱이 도착했으면 재제출
             if (latestPending.containsKey(symbol) && activeSymbols.add(symbol)) {
-                self.processLatest(symbol);
+                try {
+                    self.processLatest(symbol);
+                } catch (Exception e) {
+                    // executor 포화 등으로 제출 실패 시 activeSymbols에서 제거해야
+                    // 다음 onPriceChange 호출 때 재시도할 수 있다.
+                    activeSymbols.remove(symbol);
+                    log.warn("[PRICE_ALERT] processLatest 재제출 실패 - symbol={}, error={}", symbol, e.getMessage());
+                }
             }
         }
     }
@@ -176,9 +195,10 @@ public class PriceAlertChecker {
         LocalDateTime todayStart = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT);
         if (!priceAlertRepository.existsUntriggeredTodayByInstrumentIds(instrumentIds, todayStart)) return;
 
-        List<PriceAlert> alerts = priceAlertRepository.findActiveByInstrumentIdsWithLock(instrumentIds);
+        List<PriceAlert> alerts = priceAlertRepository.findUntriggeredTodayByInstrumentIdsWithLock(instrumentIds, todayStart);
         if (alerts.isEmpty()) return;
 
+        Map<Long, Boolean> enabledCache = new HashMap<>();
         for (PriceAlert alert : alerts) {
             String stockName = stockNameMap.get(alert.getInstrumentId());
             if (stockName == null) {
@@ -186,22 +206,34 @@ public class PriceAlertChecker {
                         alert.getPriceAlertId(), alert.getInstrumentId());
                 continue;
             }
-            processAlert(alert, event, stockName);
+            processAlert(alert, event, stockName, enabledCache);
         }
     }
 
-    private void processAlert(PriceAlert alert, PriceChangeEvent event, String stockName) {
+    private void processAlert(PriceAlert alert,
+                              PriceChangeEvent event,
+                              String stockName,
+                              Map<Long, Boolean> enabledCache) {
         try {
             if (!isTriggerConditionMet(alert, event)) return;
             if (alert.isTriggeredToday()) return;
 
-            if (!notificationSettingService.isEnabled(alert.getUserId(), NotificationType.PRICE_ALERT)) {
+            boolean enabled = enabledCache.computeIfAbsent(
+                    alert.getUserId(),
+                    userId -> notificationSettingService.isEnabled(userId, NotificationType.PRICE_ALERT)
+            );
+            if (!enabled) {
                 log.debug("[PRICE_ALERT] 가격 알림 비활성화 - userId={}", alert.getUserId());
                 return;
             }
 
             BigDecimal changeRate = event.changeRate();
-            String direction = (changeRate != null && changeRate.compareTo(BigDecimal.ZERO) > 0) ? "상승" : "하락";
+            String direction;
+            if (changeRate == null || changeRate.compareTo(BigDecimal.ZERO) == 0) {
+                direction = "보합";
+            } else {
+                direction = changeRate.compareTo(BigDecimal.ZERO) > 0 ? "상승" : "하락";
+            }
             String changeRateStr = changeRate != null
                     ? String.format("%.2f%%", changeRate.abs()) : "";
 
@@ -256,7 +288,7 @@ public class PriceAlertChecker {
 
     private String buildTitle(PriceAlert alert, String stockName, String direction, String changeRateStr) {
         if (alert.getAlertType() == AlertType.PERCENT) {
-            return String.format("%s 전일대비 %s %s", stockName, direction, changeRateStr);
+            return String.format("%s 전일대비 %s %s", stockName, changeRateStr, direction);
         }
         return String.format("%s 목표가 도달", stockName);
     }
@@ -264,8 +296,8 @@ public class PriceAlertChecker {
     private String buildMessage(PriceAlert alert, PriceChangeEvent event,
                                 String stockName, String direction, String changeRateStr) {
         if (alert.getAlertType() == AlertType.PERCENT) {
-            return String.format("%s(%s) 전일대비 %s %s 변동했습니다.",
-                    stockName, event.symbol(), direction, changeRateStr);
+            return String.format("%s(%s) 전일 대비 %s %s했습니다.",
+                    stockName, event.symbol(), changeRateStr, direction);
         }
         return String.format("%s(%s) 목표가 %s에 도달했습니다. 현재가: %s",
                 stockName, event.symbol(),

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -119,14 +119,22 @@ public class PriceAlertChecker {
     /**
      * 종목의 최신 틱 이벤트를 꺼내 조건을 평가한다.
      * 처리 완료 후 새 틱이 도착해 있으면 즉시 재제출하여 최신 틱 한 번을 더 처리한다.
+     *
+     * [트랜잭션 분리 이유]
+     * @Async + @Transactional을 같은 메서드에 두면 finally 블록의 재제출 시점에
+     * 트랜잭션이 아직 미커밋 상태라 Thread 2가 같은 행의 FOR UPDATE를 즉시 시도하여
+     * Oracle 교착 상태(ORA-00060)가 발생한다.
+     * doCheckTransactional을 동기 호출로 분리하면 해당 메서드 반환 시점 = 커밋 완료이므로
+     * finally의 재제출은 항상 커밋 이후에 실행된다.
      */
     @Async("priceCheckExecutor")
-    @Transactional
     public void processLatest(String symbol) {
         try {
             PriceChangeEvent event = latestPending.remove(symbol);
             if (event == null) return;
-            doCheckPriceChange(event);
+            self.doCheckTransactional(event);
+        } catch (CannotAcquireLockException | UnexpectedRollbackException e) {
+            log.warn("[PRICE_ALERT] 락 충돌로 스킵 - symbol={}", symbol);
         } catch (Exception e) {
             log.error("[PRICE_ALERT] 가격 변동 처리 실패 - symbol={}, error={}",
                     symbol, e.getMessage(), e);
@@ -137,6 +145,20 @@ public class PriceAlertChecker {
                 self.processLatest(symbol);
             }
         }
+    }
+
+    /**
+     * 가격 변동 조건 평가 트랜잭션.
+     * processLatest에서 동기 호출 — 반환 시점이 곧 커밋 완료 시점이다.
+     * self.doCheckTransactional()로 호출해야 @Transactional 프록시가 적용된다.
+     *
+     * TODO: 교착 상태 발생 시 해당 틱이 유실될 수 있음 (latest-only 설계상 허용).
+     *       빈번한 교착 상태가 관찰되면 실패한 이벤트를 latestPending에 재삽입하여
+     *       다음 재제출 사이클에서 처리하는 방식으로 개선을 검토할 것.
+     */
+    @Transactional
+    public void doCheckTransactional(PriceChangeEvent event) {
+        doCheckPriceChange(event);
     }
 
     private void doCheckPriceChange(PriceChangeEvent event) {

--- a/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertChecker.java
@@ -1,36 +1,26 @@
 package com.sollite.notifications.event;
 
 import com.sollite.market.domain.repository.InstrumentRepository;
-import com.sollite.notifications.domain.entity.PriceAlert;
-import com.sollite.notifications.domain.enums.AlertType;
-import com.sollite.notifications.domain.enums.NotificationType;
 import com.sollite.notifications.domain.repository.PriceAlertRepository;
 import com.sollite.notifications.service.ActivePriceAlertRegistry;
-import com.sollite.notifications.service.NotificationSettingService;
 import com.sollite.websocket.service.LsBrokerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * 가격 변동 이벤트 수신 → 사용자별 price_alerts 조건 평가 → 알림 생성.
@@ -51,10 +41,9 @@ public class PriceAlertChecker {
 
     private final PriceAlertRepository priceAlertRepository;
     private final InstrumentRepository instrumentRepository;
-    private final ApplicationEventPublisher eventPublisher;
-    private final NotificationSettingService notificationSettingService;
     private final ActivePriceAlertRegistry activePriceAlertRegistry;
     private final LsBrokerService lsBrokerService;
+    private final PriceAlertTransactionDelegate transactionDelegate;
 
     /**
      * 종목별 최신 틱 이벤트 버퍼.
@@ -97,14 +86,18 @@ public class PriceAlertChecker {
         }
 
         activePriceAlertRegistry.clear();
-
-        instrumentRepository.findAllById(countByInstrumentId.keySet()).forEach(instrument -> {
-            long count = countByInstrumentId.get(instrument.getInstrumentId());
-            for (long i = 0; i < count; i++) {
-                activePriceAlertRegistry.register(instrument.getStockCode());
-            }
-            lsBrokerService.subscribeForPriceAlert(instrument.getStockCode(), instrument.getMarketType());
-        });
+        try {
+            instrumentRepository.findAllById(countByInstrumentId.keySet()).forEach(instrument -> {
+                long count = countByInstrumentId.get(instrument.getInstrumentId());
+                for (long i = 0; i < count; i++) {
+                    activePriceAlertRegistry.register(instrument.getStockCode());
+                }
+                lsBrokerService.subscribeForPriceAlert(instrument.getStockCode(), instrument.getMarketType());
+            });
+        } catch (Exception e) {
+            log.error("[PRICE_ALERT] 레지스트리 복구 실패 — 가격 알림이 동작하지 않을 수 있습니다. error={}", e.getMessage(), e);
+            return;
+        }
 
         log.info("[PRICE_ALERT] 가격 알림 레지스트리 복구 완료 — 종목 수={}, 총 알림 수={}",
                 countByInstrumentId.size(),
@@ -136,15 +129,15 @@ public class PriceAlertChecker {
      * @Async + @Transactional을 같은 메서드에 두면 finally 블록의 재제출 시점에
      * 트랜잭션이 아직 미커밋 상태라 Thread 2가 같은 행의 FOR UPDATE를 즉시 시도하여
      * Oracle 교착 상태(ORA-00060)가 발생한다.
-     * doCheckTransactional을 동기 호출로 분리하면 해당 메서드 반환 시점 = 커밋 완료이므로
-     * finally의 재제출은 항상 커밋 이후에 실행된다.
+     * PriceAlertTransactionDelegate.execute()를 동기 호출로 분리하면 해당 메서드 반환 시점 =
+     * 커밋 완료이므로 finally의 재제출은 항상 커밋 이후에 실행된다.
      */
     @Async("priceCheckExecutor")
     public void processLatest(String symbol) {
         try {
             PriceChangeEvent event = latestPending.remove(symbol);
             if (event == null) return;
-            self.doCheckTransactional(event);
+            transactionDelegate.execute(event);
         } catch (CannotAcquireLockException | UnexpectedRollbackException e) {
             log.warn("[PRICE_ALERT] 락 충돌로 스킵 - symbol={}", symbol);
         } catch (Exception e) {
@@ -164,144 +157,5 @@ public class PriceAlertChecker {
                 }
             }
         }
-    }
-
-    /**
-     * 가격 변동 조건 평가 트랜잭션.
-     * processLatest에서 동기 호출 — 반환 시점이 곧 커밋 완료 시점이다.
-     * self.doCheckTransactional()로 호출해야 @Transactional 프록시가 적용된다.
-     *
-     * TODO: 교착 상태 발생 시 해당 틱이 유실될 수 있음 (latest-only 설계상 허용).
-     *       빈번한 교착 상태가 관찰되면 실패한 이벤트를 latestPending에 재삽입하여
-     *       다음 재제출 사이클에서 처리하는 방식으로 개선을 검토할 것.
-     */
-    @Transactional
-    public void doCheckTransactional(PriceChangeEvent event) {
-        doCheckPriceChange(event);
-    }
-
-    private void doCheckPriceChange(PriceChangeEvent event) {
-        var instruments = instrumentRepository.findActiveByStockCode(event.symbol());
-        if (instruments.isEmpty()) return;
-
-        List<Long> instrumentIds = instruments.stream()
-                .map(i -> i.getInstrumentId())
-                .sorted()
-                .toList();
-        Map<Long, String> stockNameMap = instruments.stream()
-                .collect(Collectors.toMap(i -> i.getInstrumentId(), i -> i.getStockName()));
-
-        // 당일 미트리거 알림이 없으면 PESSIMISTIC_WRITE 락 진입 생략
-        LocalDateTime todayStart = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT);
-        if (!priceAlertRepository.existsUntriggeredTodayByInstrumentIds(instrumentIds, todayStart)) return;
-
-        List<PriceAlert> alerts = priceAlertRepository.findUntriggeredTodayByInstrumentIdsWithLock(instrumentIds, todayStart);
-        if (alerts.isEmpty()) return;
-
-        Map<Long, Boolean> enabledCache = new HashMap<>();
-        for (PriceAlert alert : alerts) {
-            String stockName = stockNameMap.get(alert.getInstrumentId());
-            if (stockName == null) {
-                log.warn("[PRICE_ALERT] instrumentId 불일치 - alertId={}, instrumentId={}",
-                        alert.getPriceAlertId(), alert.getInstrumentId());
-                continue;
-            }
-            processAlert(alert, event, stockName, enabledCache);
-        }
-    }
-
-    private void processAlert(PriceAlert alert,
-                              PriceChangeEvent event,
-                              String stockName,
-                              Map<Long, Boolean> enabledCache) {
-        try {
-            if (!isTriggerConditionMet(alert, event)) return;
-            if (alert.isTriggeredToday()) return;
-
-            boolean enabled = enabledCache.computeIfAbsent(
-                    alert.getUserId(),
-                    userId -> notificationSettingService.isEnabled(userId, NotificationType.PRICE_ALERT)
-            );
-            if (!enabled) {
-                log.debug("[PRICE_ALERT] 가격 알림 비활성화 - userId={}", alert.getUserId());
-                return;
-            }
-
-            BigDecimal changeRate = event.changeRate();
-            String direction;
-            if (changeRate == null || changeRate.compareTo(BigDecimal.ZERO) == 0) {
-                direction = "보합";
-            } else {
-                direction = changeRate.compareTo(BigDecimal.ZERO) > 0 ? "상승" : "하락";
-            }
-            String changeRateStr = changeRate != null
-                    ? String.format("%.2f%%", changeRate.abs()) : "";
-
-            eventPublisher.publishEvent(new PriceAlertTriggeredEvent(
-                    alert.getUserId(),
-                    NotificationType.PRICE_ALERT,
-                    buildTitle(alert, stockName, direction, changeRateStr),
-                    buildMessage(alert, event, stockName, direction, changeRateStr),
-                    "INSTRUMENT",
-                    event.symbol(),
-                    alert.getPriceAlertId()
-            ));
-
-            alert.recordTrigger();
-
-            log.info("[PRICE_ALERT] 알림 이벤트 발행 - alertId={}, userId={}, symbol={}",
-                    alert.getPriceAlertId(), alert.getUserId(), event.symbol());
-
-        } catch (Exception e) {
-            log.error("[PRICE_ALERT] 개별 알림 처리 실패 - alertId={}, error={}",
-                    alert.getPriceAlertId(), e.getMessage(), e);
-        }
-    }
-
-    private boolean isTriggerConditionMet(PriceAlert alert, PriceChangeEvent event) {
-        return switch (alert.getAlertType()) {
-            case PERCENT -> checkPercentTrigger(alert, event.changeRate());
-            case PRICE -> checkPriceTrigger(alert, event.price());
-        };
-    }
-
-    private boolean checkPercentTrigger(PriceAlert alert, BigDecimal changeRate) {
-        if (changeRate == null || alert.getThresholdPercent() == null) return false;
-        return switch (alert.getDirection()) {
-            case UP   -> changeRate.compareTo(alert.getThresholdPercent()) >= 0;
-            case DOWN -> changeRate.negate().compareTo(alert.getThresholdPercent()) >= 0;
-            case BOTH -> changeRate.abs().compareTo(alert.getThresholdPercent()) >= 0;
-        };
-    }
-
-    private boolean checkPriceTrigger(PriceAlert alert, BigDecimal currentPrice) {
-        if (currentPrice == null || alert.getTargetPrice() == null) return false;
-        return switch (alert.getDirection()) {
-            case UP   -> currentPrice.compareTo(alert.getTargetPrice()) >= 0;
-            case DOWN -> currentPrice.compareTo(alert.getTargetPrice()) <= 0;
-            case BOTH -> {
-                log.warn("[PRICE_ALERT] BOTH+PRICE 조합은 지원하지 않습니다. alertId={}", alert.getPriceAlertId());
-                yield false;
-            }
-        };
-    }
-
-    private String buildTitle(PriceAlert alert, String stockName, String direction, String changeRateStr) {
-        if (alert.getAlertType() == AlertType.PERCENT) {
-            return String.format("%s 전일대비 %s %s", stockName, changeRateStr, direction);
-        }
-        return String.format("%s 목표가 도달", stockName);
-    }
-
-    private String buildMessage(PriceAlert alert, PriceChangeEvent event,
-                                String stockName, String direction, String changeRateStr) {
-        if (alert.getAlertType() == AlertType.PERCENT) {
-            return String.format("%s(%s) 전일 대비 %s %s했습니다.",
-                    stockName, event.symbol(), changeRateStr, direction);
-        }
-        return String.format("%s(%s) 목표가 %s에 도달했습니다. 현재가: %s",
-                stockName, event.symbol(),
-                alert.getTargetPrice().toPlainString(),
-                event.price().toPlainString());
     }
 }

--- a/src/main/java/com/sollite/notifications/event/PriceAlertTransactionDelegate.java
+++ b/src/main/java/com/sollite/notifications/event/PriceAlertTransactionDelegate.java
@@ -1,0 +1,173 @@
+package com.sollite.notifications.event;
+
+import com.sollite.market.domain.repository.InstrumentRepository;
+import com.sollite.notifications.domain.entity.PriceAlert;
+import com.sollite.notifications.domain.enums.AlertType;
+import com.sollite.notifications.domain.enums.NotificationType;
+import com.sollite.notifications.domain.repository.PriceAlertRepository;
+import com.sollite.notifications.service.NotificationSettingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 가격 변동 조건 평가 트랜잭션 위임 빈.
+ * PriceAlertChecker(@Async)와 트랜잭션 경계를 명확히 분리하기 위해 별도 @Component로 추출했다.
+ * 이 빈을 통해 호출하면 Spring 프록시가 적용되어 반환 시점 = 커밋 완료가 보장된다.
+ *
+ * TODO: 교착 상태 발생 시 해당 틱이 유실될 수 있음 (latest-only 설계상 허용).
+ *       빈번한 교착 상태가 관찰되면 실패한 이벤트를 latestPending에 재삽입하여
+ *       다음 재제출 사이클에서 처리하는 방식으로 개선을 검토할 것.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class PriceAlertTransactionDelegate {
+
+    private final PriceAlertRepository priceAlertRepository;
+    private final InstrumentRepository instrumentRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final NotificationSettingService notificationSettingService;
+
+    @Transactional
+    void execute(PriceChangeEvent event) {
+        doCheckPriceChange(event);
+    }
+
+    private void doCheckPriceChange(PriceChangeEvent event) {
+        var instruments = instrumentRepository.findActiveByStockCode(event.symbol());
+        if (instruments.isEmpty()) return;
+
+        List<Long> instrumentIds = instruments.stream()
+                .map(i -> i.getInstrumentId())
+                .sorted()
+                .toList();
+        Map<Long, String> stockNameMap = instruments.stream()
+                .collect(Collectors.toMap(i -> i.getInstrumentId(), i -> i.getStockName()));
+
+        // 당일 미트리거 알림이 없으면 PESSIMISTIC_WRITE 락 진입 생략
+        LocalDateTime todayStart = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT);
+        if (!priceAlertRepository.existsUntriggeredTodayByInstrumentIds(instrumentIds, todayStart)) return;
+
+        List<PriceAlert> alerts = priceAlertRepository.findUntriggeredTodayByInstrumentIdsWithLock(instrumentIds, todayStart);
+        if (alerts.isEmpty()) return;
+
+        Map<Long, Boolean> enabledCache = new HashMap<>();
+        for (PriceAlert alert : alerts) {
+            String stockName = stockNameMap.get(alert.getInstrumentId());
+            if (stockName == null) {
+                log.warn("[PRICE_ALERT] instrumentId 불일치 - alertId={}, instrumentId={}",
+                        alert.getPriceAlertId(), alert.getInstrumentId());
+                continue;
+            }
+            processAlert(alert, event, stockName, enabledCache);
+        }
+    }
+
+    private void processAlert(PriceAlert alert,
+                              PriceChangeEvent event,
+                              String stockName,
+                              Map<Long, Boolean> enabledCache) {
+        try {
+            if (!isTriggerConditionMet(alert, event)) return;
+            if (alert.isTriggeredToday()) return;
+
+            // NotificationSettingService가 내부 캐시를 제공하지 않으므로 틱 처리 내 중복 조회 방지
+            boolean enabled = enabledCache.computeIfAbsent(
+                    alert.getUserId(),
+                    userId -> notificationSettingService.isEnabled(userId, NotificationType.PRICE_ALERT)
+            );
+            if (!enabled) {
+                log.debug("[PRICE_ALERT] 가격 알림 비활성화 - userId={}", alert.getUserId());
+                return;
+            }
+
+            BigDecimal changeRate = event.changeRate();
+            String direction;
+            if (changeRate == null || changeRate.compareTo(BigDecimal.ZERO) == 0) {
+                direction = "보합";
+            } else {
+                direction = changeRate.compareTo(BigDecimal.ZERO) > 0 ? "상승" : "하락";
+            }
+            String changeRateStr = changeRate != null
+                    ? String.format("%.2f%%", changeRate.abs()) : "";
+
+            eventPublisher.publishEvent(new PriceAlertTriggeredEvent(
+                    alert.getUserId(),
+                    NotificationType.PRICE_ALERT,
+                    buildTitle(alert, stockName, direction, changeRateStr),
+                    buildMessage(alert, event, stockName, direction, changeRateStr),
+                    "INSTRUMENT",
+                    event.symbol(),
+                    alert.getPriceAlertId()
+            ));
+
+            alert.recordTrigger();
+
+            log.info("[PRICE_ALERT] 알림 이벤트 발행 - alertId={}, userId={}, symbol={}",
+                    alert.getPriceAlertId(), alert.getUserId(), event.symbol());
+
+        } catch (Exception e) {
+            log.error("[PRICE_ALERT] 개별 알림 처리 실패 - alertId={}, error={}",
+                    alert.getPriceAlertId(), e.getMessage(), e);
+        }
+    }
+
+    private boolean isTriggerConditionMet(PriceAlert alert, PriceChangeEvent event) {
+        return switch (alert.getAlertType()) {
+            case PERCENT -> checkPercentTrigger(alert, event.changeRate());
+            case PRICE -> checkPriceTrigger(alert, event.price());
+        };
+    }
+
+    private boolean checkPercentTrigger(PriceAlert alert, BigDecimal changeRate) {
+        if (changeRate == null || alert.getThresholdPercent() == null) return false;
+        return switch (alert.getDirection()) {
+            case UP   -> changeRate.compareTo(alert.getThresholdPercent()) >= 0;
+            case DOWN -> changeRate.negate().compareTo(alert.getThresholdPercent()) >= 0;
+            case BOTH -> changeRate.abs().compareTo(alert.getThresholdPercent()) >= 0;
+        };
+    }
+
+    private boolean checkPriceTrigger(PriceAlert alert, BigDecimal currentPrice) {
+        if (currentPrice == null || alert.getTargetPrice() == null) return false;
+        return switch (alert.getDirection()) {
+            case UP   -> currentPrice.compareTo(alert.getTargetPrice()) >= 0;
+            case DOWN -> currentPrice.compareTo(alert.getTargetPrice()) <= 0;
+            case BOTH -> {
+                log.warn("[PRICE_ALERT] BOTH+PRICE 조합은 지원하지 않습니다. alertId={}", alert.getPriceAlertId());
+                yield false;
+            }
+        };
+    }
+
+    private String buildTitle(PriceAlert alert, String stockName, String direction, String changeRateStr) {
+        if (alert.getAlertType() == AlertType.PERCENT) {
+            return String.format("%s 전일대비 %s %s", stockName, changeRateStr, direction);
+        }
+        return String.format("%s 목표가 도달", stockName);
+    }
+
+    private String buildMessage(PriceAlert alert, PriceChangeEvent event,
+                                String stockName, String direction, String changeRateStr) {
+        if (alert.getAlertType() == AlertType.PERCENT) {
+            return String.format("%s(%s) 전일 대비 %s %s했습니다.",
+                    stockName, event.symbol(), changeRateStr, direction);
+        }
+        return String.format("%s(%s) 목표가 %s에 도달했습니다. 현재가: %s",
+                stockName, event.symbol(),
+                alert.getTargetPrice().toPlainString(),
+                event.price().toPlainString());
+    }
+}

--- a/src/main/java/com/sollite/notifications/service/ActivePriceAlertRegistry.java
+++ b/src/main/java/com/sollite/notifications/service/ActivePriceAlertRegistry.java
@@ -35,4 +35,9 @@ public class ActivePriceAlertRegistry {
         AtomicInteger cnt = counts.get(stockCode);
         return cnt != null && cnt.get() > 0;
     }
+
+    /** 서버 기동 시 레지스트리 복구 전 전체 초기화용 */
+    public void clear() {
+        counts.clear();
+    }
 }

--- a/src/main/java/com/sollite/notifications/service/NotificationService.java
+++ b/src/main/java/com/sollite/notifications/service/NotificationService.java
@@ -51,6 +51,14 @@ public class NotificationService {
         notificationRepository.markAllAsRead(userId, LocalDateTime.now());
     }
 
+    @Transactional
+    public void deleteNotification(Long userId, Long notificationId) {
+        Notification notification = notificationRepository
+                .findByNotificationIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new BusinessException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+        notificationRepository.delete(notification);
+    }
+
     /**
      * 알림 저장 + WebSocket 실시간 전송.
      * REQUIRES_NEW: PriceAlertChecker outer 트랜잭션과 격리 — save() 실패가 외부 트랜잭션을 오염시키지 않는다.

--- a/src/main/java/com/sollite/notifications/service/PriceAlertSubscriptionManager.java
+++ b/src/main/java/com/sollite/notifications/service/PriceAlertSubscriptionManager.java
@@ -53,7 +53,6 @@ public class PriceAlertSubscriptionManager {
             activePriceAlertRegistry.unregister(stockCode);
             log.error("[PRICE_ALERT_SUB] activate 실패 — registry 롤백 완료. stockCode={}, error={}",
                     stockCode, e.getMessage(), e);
-            return;
         }
         log.info("[PRICE_ALERT_SUB] activate - stockCode={}, marketType={}", stockCode, marketType);
     }
@@ -66,7 +65,6 @@ public class PriceAlertSubscriptionManager {
             // unregister는 이미 완료. LS가 계속 틱을 보내더라도 hasActiveAlerts() = false이므로 이벤트 미발행.
             log.error("[PRICE_ALERT_SUB] deactivate 중 LS 구독 해제 실패 — stockCode={}, error={}",
                     stockCode, e.getMessage(), e);
-            return;
         }
         log.info("[PRICE_ALERT_SUB] deactivate - stockCode={}, marketType={}", stockCode, marketType);
     }

--- a/src/main/java/com/sollite/notifications/service/PriceAlertSubscriptionManager.java
+++ b/src/main/java/com/sollite/notifications/service/PriceAlertSubscriptionManager.java
@@ -1,0 +1,73 @@
+package com.sollite.notifications.service;
+
+import com.sollite.websocket.service.LsBrokerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * 가격 알림 활성/비활성에 따른 인메모리 상태와 LS 구독 상태를
+ * 트랜잭션 커밋 이후에 반영한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PriceAlertSubscriptionManager {
+
+    private final ActivePriceAlertRegistry activePriceAlertRegistry;
+    private final LsBrokerService lsBrokerService;
+
+    public void activate(String stockCode, String marketType) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    doActivate(stockCode, marketType);
+                }
+            });
+            return;
+        }
+        doActivate(stockCode, marketType);
+    }
+
+    public void deactivate(String stockCode, String marketType) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    doDeactivate(stockCode, marketType);
+                }
+            });
+            return;
+        }
+        doDeactivate(stockCode, marketType);
+    }
+
+    private void doActivate(String stockCode, String marketType) {
+        activePriceAlertRegistry.register(stockCode);
+        try {
+            lsBrokerService.subscribeForPriceAlert(stockCode, marketType);
+        } catch (Exception e) {
+            activePriceAlertRegistry.unregister(stockCode);
+            log.error("[PRICE_ALERT_SUB] activate 실패 — registry 롤백 완료. stockCode={}, error={}",
+                    stockCode, e.getMessage(), e);
+            return;
+        }
+        log.info("[PRICE_ALERT_SUB] activate - stockCode={}, marketType={}", stockCode, marketType);
+    }
+
+    private void doDeactivate(String stockCode, String marketType) {
+        activePriceAlertRegistry.unregister(stockCode);
+        try {
+            lsBrokerService.unsubscribeForPriceAlert(stockCode, marketType);
+        } catch (Exception e) {
+            // unregister는 이미 완료. LS가 계속 틱을 보내더라도 hasActiveAlerts() = false이므로 이벤트 미발행.
+            log.error("[PRICE_ALERT_SUB] deactivate 중 LS 구독 해제 실패 — stockCode={}, error={}",
+                    stockCode, e.getMessage(), e);
+            return;
+        }
+        log.info("[PRICE_ALERT_SUB] deactivate - stockCode={}, marketType={}", stockCode, marketType);
+    }
+}

--- a/src/main/java/com/sollite/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/sollite/watchlist/service/WatchlistService.java
@@ -14,7 +14,7 @@ import com.sollite.notifications.domain.enums.AlertDirection;
 import com.sollite.notifications.domain.enums.AlertType;
 import com.sollite.notifications.domain.repository.NotificationSettingRepository;
 import com.sollite.notifications.domain.repository.PriceAlertRepository;
-import com.sollite.notifications.service.ActivePriceAlertRegistry;
+import com.sollite.notifications.service.PriceAlertSubscriptionManager;
 import com.sollite.watchlist.domain.entity.WatchlistItem;
 import com.sollite.watchlist.domain.repository.WatchlistItemRepository;
 import com.sollite.watchlist.dto.WatchlistAddRequest;
@@ -48,7 +48,7 @@ public class WatchlistService {
     private final ObjectMapper objectMapper;
     private final PriceAlertRepository priceAlertRepository;
     private final NotificationSettingRepository notificationSettingRepository;
-    private final ActivePriceAlertRegistry activePriceAlertRegistry;
+    private final PriceAlertSubscriptionManager priceAlertSubscriptionManager;
 
     @Transactional(readOnly = true)
     public List<WatchlistItemResponse> getWatchlist(Long userId) {
@@ -132,7 +132,7 @@ public class WatchlistService {
                 .thresholdPercent(threshold)
                 .direction(AlertDirection.BOTH)
                 .build());
-        activePriceAlertRegistry.register(instrument.getStockCode());
+        priceAlertSubscriptionManager.activate(instrument.getStockCode(), instrument.getMarketType());
     }
 
     @Transactional
@@ -149,7 +149,7 @@ public class WatchlistService {
 
         // 관심종목 삭제 시 연관 가격 알림 제거 및 레지스트리 갱신
         priceAlertRepository.deleteByUserIdAndInstrumentId(userId, instrument.getInstrumentId());
-        activePriceAlertRegistry.unregister(stockCode);
+        priceAlertSubscriptionManager.deactivate(stockCode, instrument.getMarketType());
     }
 
     @Transactional

--- a/src/main/java/com/sollite/websocket/service/LsBrokerService.java
+++ b/src/main/java/com/sollite/websocket/service/LsBrokerService.java
@@ -60,8 +60,8 @@ public class LsBrokerService {
     private final ReactorNettyWebSocketClient lsClient = new ReactorNettyWebSocketClient();
 
     // LS 연결 상태
-    private Disposable lsConnection;
-    private Sinks.Many<String> outboundSink;
+    private volatile Disposable lsConnection;
+    private volatile Sinks.Many<String> outboundSink;
     private final AtomicBoolean connected = new AtomicBoolean(false);
     private final AtomicBoolean connecting = new AtomicBoolean(false);
     private final AtomicBoolean reconnectScheduled = new AtomicBoolean(false);
@@ -71,6 +71,8 @@ public class LsBrokerService {
     private final Map<String, AtomicInteger> subscriberCount = new ConcurrentHashMap<>();
     // 현재 LS에 등록된 종목: "UH1:005930"
     private final Set<String> activeSubscriptions = ConcurrentHashMap.newKeySet();
+    // 가격 알림 경로로 구독된 종목: "US3:005930". subscribeForPriceAlert 멱등성 보장용.
+    private final Set<String> priceAlertSubscribedKeys = ConcurrentHashMap.newKeySet();
     // 토픽별 마지막 수신 값: "/topic/stock/trade/005930" → JSON
     private final Map<String, String> lastValues = new ConcurrentHashMap<>();
 
@@ -158,6 +160,43 @@ public class LsBrokerService {
             // 체결/차트가 중복 반영될 수 있다. 스냅샷은 REST/초기 조회 경로에 맡긴다.
             log.info("[SUBSCRIBE] lastValue 보유 확인: topic={}, 신규 실시간 수신 대기", topicPrefix + key);
         }
+    }
+
+    /**
+     * 가격 알림용 종목 구독. marketType → trCd 변환 후 subscribe() 위임.
+     * 서버 기동 시 레지스트리 복구, 관심종목 추가 시 호출된다.
+     * priceAlertSubscribedKeys로 멱등성 보장 — recoverRegistry 재호출 시 subscriberCount 중복 증가 방지.
+     */
+    public void subscribeForPriceAlert(String stockCode, String marketType) {
+        String trCd = resolvePriceAlertTrCd(marketType);
+        if (trCd == null) return;
+        if (priceAlertSubscribedKeys.add(trCd + ":" + stockCode)) {
+            subscribe(trCd, stockCode);
+        }
+    }
+
+    /**
+     * 가격 알림용 종목 구독 해제. marketType → trCd 변환 후 unsubscribe() 위임.
+     * 관심종목 삭제 시 호출된다.
+     * priceAlertSubscribedKeys에 등록된 경우에만 unsubscribe() 호출하여 카운터 오염 방지.
+     */
+    public void unsubscribeForPriceAlert(String stockCode, String marketType) {
+        String trCd = resolvePriceAlertTrCd(marketType);
+        if (trCd == null) return;
+        if (priceAlertSubscribedKeys.remove(trCd + ":" + stockCode)) {
+            unsubscribe(trCd, stockCode);
+        }
+    }
+
+    private String resolvePriceAlertTrCd(String marketType) {
+        return switch (marketType) {
+            case "KOSPI", "KOSDAQ" -> "US3";
+            case "NASDAQ", "NYSE", "AMEX" -> "GSC";
+            default -> {
+                log.warn("[PRICE_ALERT] 알 수 없는 marketType — LS 구독 스킵: {}", marketType);
+                yield null;
+            }
+        };
     }
 
     /**
@@ -356,24 +395,23 @@ public class LsBrokerService {
                 safeSnapshotSet(CURRENCY_SNAPSHOT_PREFIX + topic, bodyJson, CURRENCY_SNAPSHOT_TTL);
             }
 
-            // 체결 틱(US3/GSC)이고 대기 LIMIT 주문이 있는 종목일 때만 주문 매칭 이벤트 발행
-            if (("US3".equals(trCd) || "GSC".equals(trCd))
-                    && activeOrderRegistry.hasActiveOrders(trCd, symbol)) {
-                java.math.BigDecimal tickPrice = extractTradePrice(trCd, body);
-                if (tickPrice != null) {
-                    applicationEventPublisher.publishEvent(
-                            new MarketTickEvent(symbol, tickPrice, trCd, java.time.Instant.now()));
-                }
-            }
-
-            // 체결 틱(US3/GSC)이고 활성 가격 알림이 있는 종목일 때만 가격 변동 이벤트 발행
-            if (("US3".equals(trCd) || "GSC".equals(trCd))
-                    && activePriceAlertRegistry.hasActiveAlerts(symbol)) {
-                java.math.BigDecimal tickPrice = extractTradePrice(trCd, body);
-                if (tickPrice != null) {
-                    applicationEventPublisher.publishEvent(
-                            new PriceChangeEvent(symbol, tickPrice, extractChangeRate(body),
-                                    trCd, java.time.Instant.now()));
+            // 체결 틱(US3/GSC): 주문 매칭 → 가격 알림 순으로 발행 (주문 우선)
+            if ("US3".equals(trCd) || "GSC".equals(trCd)) {
+                boolean hasOrder = activeOrderRegistry.hasActiveOrders(trCd, symbol);
+                boolean hasAlert = activePriceAlertRegistry.hasActiveAlerts(symbol);
+                if (hasOrder || hasAlert) {
+                    java.math.BigDecimal tickPrice = extractTradePrice(trCd, body);
+                    if (tickPrice != null) {
+                        if (hasOrder) {
+                            applicationEventPublisher.publishEvent(
+                                    new MarketTickEvent(symbol, tickPrice, trCd, java.time.Instant.now()));
+                        }
+                        if (hasAlert) {
+                            applicationEventPublisher.publishEvent(
+                                    new PriceChangeEvent(symbol, tickPrice, extractChangeRate(body),
+                                            trCd, java.time.Instant.now()));
+                        }
+                    }
                 }
             }
 
@@ -385,8 +423,8 @@ public class LsBrokerService {
 
     private java.math.BigDecimal extractChangeRate(JsonNode body) {
         try {
-            if (body.has("diff")) {
-                String raw = body.get("diff").asText().replace(",", "").trim();
+            if (body.has("drate")) {
+                String raw = body.get("drate").asText().replace(",", "").trim();
                 if (!raw.isEmpty()) {
                     return new java.math.BigDecimal(raw);
                 }

--- a/src/main/java/com/sollite/websocket/service/LsBrokerService.java
+++ b/src/main/java/com/sollite/websocket/service/LsBrokerService.java
@@ -408,7 +408,7 @@ public class LsBrokerService {
                         }
                         if (hasAlert) {
                             applicationEventPublisher.publishEvent(
-                                    new PriceChangeEvent(symbol, tickPrice, extractChangeRate(body),
+                                    new PriceChangeEvent(symbol, tickPrice, extractChangeRate(trCd, body),
                                             trCd, java.time.Instant.now()));
                         }
                     }
@@ -421,16 +421,23 @@ public class LsBrokerService {
         }
     }
 
-    private java.math.BigDecimal extractChangeRate(JsonNode body) {
+    /**
+     * 등락율 추출 (TR별 필드명이 다름)
+     * US3(국내체결): drate = 등락율
+     * GSC(해외체결): rate = 등락율 (diff는 전일대비 금액)
+     */
+    private java.math.BigDecimal extractChangeRate(String trCd, JsonNode body) {
+        // US3: drate, GSC: rate
+        String fieldName = "US3".equals(trCd) ? "drate" : "rate";
         try {
-            if (body.has("drate")) {
-                String raw = body.get("drate").asText().replace(",", "").trim();
+            if (body.has(fieldName)) {
+                String raw = body.get(fieldName).asText().replace(",", "").trim();
                 if (!raw.isEmpty()) {
                     return new java.math.BigDecimal(raw);
                 }
             }
         } catch (NumberFormatException e) {
-            log.warn("[LS-MSG] 등락률 파싱 실패: body={}", body);
+            log.warn("[LS-MSG] 등락률 파싱 실패: trCd={}, body={}", trCd, body);
         }
         return null;
     }


### PR DESCRIPTION
## 연관된 이슈
* Closes #63


## 작업 내용

### 1. `@Async` + `@Transactional` 동일 메서드 적용으로 인한 교착 상태 수정

**문제**
`processLatest()`에 `@Async`와 `@Transactional`이 함께 선언되어 있었습니다.
`@Async`는 Spring 프록시 외부에서 실행되기 때문에, 메서드가 반환되는 시점과 트랜잭션이 커밋되는 시점 사이에 간격이 생깁니다.
`finally` 블록에서 다음 틱을 재제출할 때 이전 트랜잭션이 아직 커밋되지 않은 상태이므로, Thread 2가 동일 행에 `FOR UPDATE`를 즉시 시도하여 Oracle 교착 상태(ORA-00060)가 발생했습니다.

**수정 방식**
트랜잭션 경계를 별도 메서드 `doCheckTransactional()`로 분리했습니다.

```
processLatest()                     ← @Async만 담당
  └─ self.doCheckTransactional()    ← @Transactional만 담당 (self 프록시 호출로 커밋 보장)
       └─ doCheckPriceChange()
```

`self.doCheckTransactional()` 반환 시점 = 커밋 완료이므로, `finally`의 재제출은 항상 커밋 이후에 실행됩니다.

**개선점**
- 교착 상태 원천 차단
- 락 충돌(`CannotAcquireLockException`, `UnexpectedRollbackException`) 예외를 별도 핸들링하여 불필요한 ERROR 로그 제거, warn 수준으로 처리

**남은 문제점**
교착 상태 발생 시 해당 틱이 유실됩니다. 이는 latest-only 설계상 허용된 동작이나, 유실이 빈번하게 관찰될 경우 실패한 이벤트를 `latestPending`에 재삽입하여 다음 재제출 사이클에서 처리하는 방식으로 개선이 필요합니다.

---

### 2. `@Modifying` `flushAutomatically = true` 추가

`updateThresholdByUserId()` 실행 전 영속성 컨텍스트의 dirty 상태를 flush하지 않으면, 1차 캐시의 변경사항이 DB에 반영되기 전에 JPQL UPDATE가 실행되어 덮어써질 수 있었습니다.
`flushAutomatically = true`를 추가하여 UPDATE 전 flush를 보장합니다.

---

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항

> `doCheckTransactional()`이 `public`으로 열려 있어야 `self` 프록시가 적용됩니다. 접근 제어자를 좁히고 싶다면 별도 빈으로 추출하는 방식도 고려해주세요.