### PR TITLE
fix: 뉴스 summary 혼합 스키마 지원

### DIFF
--- a/src/main/java/com/sollite/news/domain/entity/NewsDocument.java
+++ b/src/main/java/com/sollite/news/domain/entity/NewsDocument.java
@@ -7,8 +7,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.util.Date;
-import java.util.List;
-import java.util.Map;
 
 @Getter
 @Document(collection = "news")
@@ -25,7 +23,11 @@ public class NewsDocument {
 
     private String content;
 
-    private Summary summary;
+    /**
+     * 국내/해외 시황 summary 스키마가 완전히 동일하지 않아 raw object로 받습니다.
+     * DTO 계층에서 필요한 필드(one_line_summary, market_event, market_sentiment)만 안전하게 추출합니다.
+     */
+    private Object summary;
 
     private String source;
 
@@ -34,22 +36,4 @@ public class NewsDocument {
 
     @Field("published_at")
     private Date publishedAt;
-
-    @Getter
-    public static class Summary {
-        private String date;
-
-        @Field("market_event")
-        private List<String> marketEvent;
-
-        @Field("market_sentiment")
-        private String marketSentiment;
-
-        @Field("one_line_summary")
-        private String oneLineSummary;
-
-        private Map<String, List<String>> sectors;
-
-        private Map<String, Map<String, List<String>>> stocks;
-    }
 }

--- a/src/main/java/com/sollite/news/dto/NewsDetailResponse.java
+++ b/src/main/java/com/sollite/news/dto/NewsDetailResponse.java
@@ -18,25 +18,15 @@ public record NewsDetailResponse(
         String publishedAt
 ) {
     public static NewsDetailResponse from(NewsDocument doc) {
-        NewsDocument.Summary summary = doc.getSummary();
-
-        String oneLineSummary = null;
-        List<String> marketEvents = List.of();
-        String marketSentiment = null;
-
-        if (summary != null) {
-            oneLineSummary  = summary.getOneLineSummary();
-            marketSentiment = summary.getMarketSentiment();
-            marketEvents    = summary.getMarketEvent() != null ? summary.getMarketEvent() : List.of();
-        }
+        NewsSummaryParser.ParsedSummary summary = NewsSummaryParser.parse(doc.getSummary());
 
         return new NewsDetailResponse(
                 doc.getNewsId(),
                 doc.getTitle(),
                 doc.getContent(),
-                oneLineSummary,
-                marketEvents,
-                marketSentiment,
+                summary.oneLineSummary(),
+                summary.marketEvents(),
+                summary.marketSentiment(),
                 doc.getSource(),
                 doc.getStockIndex(),
                 doc.getPublishedAt() != null

--- a/src/main/java/com/sollite/news/dto/NewsResponse.java
+++ b/src/main/java/com/sollite/news/dto/NewsResponse.java
@@ -20,17 +20,7 @@ public record NewsResponse(
     private static final int PREVIEW_LENGTH = 120;
 
     public static NewsResponse from(NewsDocument doc) {
-        NewsDocument.Summary summary = doc.getSummary();
-
-        String oneLineSummary = null;
-        List<String> marketEvents = List.of();
-        String marketSentiment = null;
-
-        if (summary != null) {
-            oneLineSummary  = summary.getOneLineSummary();
-            marketSentiment = summary.getMarketSentiment();
-            marketEvents    = summary.getMarketEvent() != null ? summary.getMarketEvent() : List.of();
-        }
+        NewsSummaryParser.ParsedSummary summary = NewsSummaryParser.parse(doc.getSummary());
 
         String contentPreview = null;
         if (doc.getContent() != null) {
@@ -43,9 +33,9 @@ public record NewsResponse(
         return new NewsResponse(
                 doc.getNewsId(),
                 doc.getTitle(),
-                oneLineSummary,
-                marketEvents,
-                marketSentiment,
+                summary.oneLineSummary(),
+                summary.marketEvents(),
+                summary.marketSentiment(),
                 doc.getSource(),
                 doc.getStockIndex(),
                 doc.getPublishedAt() != null

--- a/src/main/java/com/sollite/news/dto/NewsSummaryParser.java
+++ b/src/main/java/com/sollite/news/dto/NewsSummaryParser.java
@@ -1,0 +1,57 @@
+package com.sollite.news.dto;
+
+import java.util.List;
+import java.util.Map;
+
+final class NewsSummaryParser {
+
+    private NewsSummaryParser() {
+    }
+
+    static ParsedSummary parse(Object rawSummary) {
+        if (rawSummary instanceof String summaryText) {
+            return new ParsedSummary(summaryText, List.of(), null);
+        }
+
+        if (!(rawSummary instanceof Map<?, ?> summaryMap)) {
+            return ParsedSummary.empty();
+        }
+
+        String oneLineSummary = getString(summaryMap, "one_line_summary", "summary");
+        String marketSentiment = getString(summaryMap, "market_sentiment");
+        List<String> marketEvents = getStringList(summaryMap.get("market_event"));
+
+        return new ParsedSummary(oneLineSummary, marketEvents, marketSentiment);
+    }
+
+    private static String getString(Map<?, ?> source, String... keys) {
+        for (String key : keys) {
+            Object value = source.get(key);
+            if (value instanceof String text && !text.isBlank()) {
+                return text;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> getStringList(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+
+        return list.stream()
+                .filter(item -> item != null && !String.valueOf(item).isBlank())
+                .map(String::valueOf)
+                .toList();
+    }
+
+    record ParsedSummary(
+            String oneLineSummary,
+            List<String> marketEvents,
+            String marketSentiment
+    ) {
+        static ParsedSummary empty() {
+            return new ParsedSummary(null, List.of(), null);
+        }
+    }
+}

--- a/src/test/java/com/sollite/news/dto/NewsSummaryParserTest.java
+++ b/src/test/java/com/sollite/news/dto/NewsSummaryParserTest.java
@@ -1,0 +1,52 @@
+package com.sollite.news.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NewsSummaryParserTest {
+
+    @Test
+    void parsesDomesticSummaryShape() {
+        Object rawSummary = Map.of(
+                "one_line_summary", "국내 시황 요약입니다.",
+                "market_sentiment", "중립",
+                "market_event", List.of("이벤트1", "이벤트2"),
+                "sectors", Map.of("kospi", List.of("반도체(+1.2%)"))
+        );
+
+        NewsSummaryParser.ParsedSummary parsed = NewsSummaryParser.parse(rawSummary);
+
+        assertThat(parsed.oneLineSummary()).isEqualTo("국내 시황 요약입니다.");
+        assertThat(parsed.marketSentiment()).isEqualTo("중립");
+        assertThat(parsed.marketEvents()).containsExactly("이벤트1", "이벤트2");
+    }
+
+    @Test
+    void parsesUsSummaryShapeWithArraySectors() {
+        Object rawSummary = Map.of(
+                "one_line_summary", "미국 시황 요약입니다.",
+                "market_event", List.of("이벤트A"),
+                "sectors", List.of("기술(+6.24%)"),
+                "stocks", Map.of("up", List.of("Nvidia(+2.1%)"))
+        );
+
+        NewsSummaryParser.ParsedSummary parsed = NewsSummaryParser.parse(rawSummary);
+
+        assertThat(parsed.oneLineSummary()).isEqualTo("미국 시황 요약입니다.");
+        assertThat(parsed.marketSentiment()).isNull();
+        assertThat(parsed.marketEvents()).containsExactly("이벤트A");
+    }
+
+    @Test
+    void parsesPlainStringSummary() {
+        NewsSummaryParser.ParsedSummary parsed = NewsSummaryParser.parse("문자열 요약");
+
+        assertThat(parsed.oneLineSummary()).isEqualTo("문자열 요약");
+        assertThat(parsed.marketEvents()).isEmpty();
+        assertThat(parsed.marketSentiment()).isNull();
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> 없음

## 작업 내용

> Mongo `news` 컬렉션의 국내/해외 시황 `summary` 스키마 차이로 `/api/news` 조회 시 발생하던 `MappingException`을 수정했습니다.

- `NewsDocument.summary`를 raw object로 받아 혼합 스키마를 허용하도록 변경
- `NewsSummaryParser`를 추가해 `one_line_summary`, `market_event`, `market_sentiment`를 안전하게 추출하도록 변경
- `NewsResponse`, `NewsDetailResponse`가 parser를 사용하도록 수정
- 국내형/해외형/string summary 케이스를 다루는 테스트 추가
- 검증: `./gradlew compileJava` 성공
- 참고: 전체 `./gradlew test`는 기존 `LsGshResTest` 컴파일 오류로 완료되지 않았습니다.

### 스크린샷 (선택)

없음

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [x] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

> AI 크롤러에서 국내/해외 시황 summary shape가 서로 달라 현재는 backend가 이를 흡수하도록 처리했습니다. 응답 필드 범위가 의도와 맞는지 확인 부탁드립니다.
