### PR TITLE
fix(widget): 프리셋 섹터 종목을 시총 기준으로 보정

### DIFF
--- a/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
+++ b/src/main/java/com/sollite/market/service/LsMarketServiceImpl.java
@@ -1250,7 +1250,7 @@ class LsMarketServiceImpl implements MarketService {
             for (Instrument inst : unrankedInstruments) {
                 filtered.add(new StockRankingItem(
                         0, inst.getStockCode(), inst.getMarketType(), inst.getStockName(),
-                        0L, SIGN_UNCHANGED, 0L, 0.0, 0L, 0L, 0L, null,
+                        0L, SIGN_UNCHANGED, 0L, 0.0, 0L, 0L, inst.getMarketCap(), null,
                         null, null, null, null, null, null, null, null, null, null
                 ));
             }

--- a/src/main/java/com/sollite/widget/service/DashboardService.java
+++ b/src/main/java/com/sollite/widget/service/DashboardService.java
@@ -32,6 +32,7 @@ public class DashboardService {
 
     private static final String STOCK_CHART_TYPE = "stock-chart";
     private static final String STOCK_NEWS_TYPE = "stock-news";
+    private static final String PRESET_RANKING_TYPE = "market-cap";
 
     private final DashboardRepository dashboardRepository;
     private final MarketService marketService;
@@ -90,8 +91,8 @@ public class DashboardService {
 
     @Transactional
     public List<DashboardPageResponse> applyPreset(Long userId, PresetApplyRequest request) {
-        // getThemeRanking은 @Cacheable 처리되어 있어 캐시 히트 시 즉시 반환됨
-        List<StockRankingItem> ranking = marketService.getThemeRanking(request.theme(), "trading-value");
+        // 프리셋 섹터 선택 UI는 시가총액 기준 상위 종목을 기대하므로 동일 기준으로 채운다.
+        List<StockRankingItem> ranking = marketService.getThemeRanking(request.theme(), PRESET_RANKING_TYPE);
         StockRankingItem topMarketCapStock = marketService.getTopMarketCapStock(request.theme());
 
         List<Dashboard> existing = dashboardRepository.findAllByUserIdWithWidgets(userId);


### PR DESCRIPTION
## 연관된 이슈

> 없음

## 작업 내용

> 프리셋 섹터 적용 시 종목 선정 기준과 응답 보정 값을 정리했습니다.

- 프리셋 적용 시 `getThemeRanking(theme, "market-cap")`를 사용하도록 변경
- 테마 랭킹 fallback 종목도 `instruments.market_cap` 실제 값을 응답에 포함하도록 수정
- 운영 DB 확인 결과 `instrument_theme_mappings`와 `instruments.market_cap` 연결 자체는 정상이며, 일부 테마 매핑 데이터가 기대와 다를 수 있음을 확인

### 스크린샷 (선택)

없음

## 체크리스트

- [x] 코드가 정상적으로 빌드되는지 확인했나요?
- [ ] 관련 테스트를 작성하거나 수정했나요?
- [x] 불필요한 코드나 주석을 제거했나요?

## 리뷰 요구사항(선택)

운영 DB의 테마 매핑 데이터는 별도 정리가 필요할 수 있습니다.