### PR TITLE
fix(widget): 대시보드 삭제 시 FK 위반 오류 수정

### DIFF
--- a/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
+++ b/src/main/java/com/sollite/widget/domain/repository/DashboardRepository.java
@@ -14,6 +14,6 @@ public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
     List<Dashboard> findAllByUserIdWithWidgets(@Param("userId") Long userId);
 
     @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM Dashboard d WHERE d.userId = :userId")
+    @Query(value = "DELETE FROM dashboards WHERE user_id = :userId", nativeQuery = true)
     void deleteAllByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 원인
`deleteAllByUserId`가 JPQL 벌크 삭제로 구현되어 JPA cascade를 우회함
→ `widget_layouts`가 남아있는 상태에서 `dashboards` 삭제 시 FK 위반 발생

## 영향 범위
- 위젯 추가/수정 후 저장 실패
- 프리셋 적용 실패

## 수정
JPQL → 네이티브 쿼리로 변경하여 DB `ON DELETE CASCADE` 동작